### PR TITLE
update docker to work for javametrics

### DIFF
--- a/generators/dockertools/templates/java/Dockerfile.template
+++ b/generators/dockertools/templates/java/Dockerfile.template
@@ -3,6 +3,10 @@ FROM websphere-liberty:webProfile7
 MAINTAINER IBM Java engineering at IBM Cloud
 {{#has buildType 'maven'}}
 COPY /target/liberty/wlp/usr/servers/defaultServer /config/
+{{#javametrics}}
+COPY /target/liberty/wlp/usr/shared/resources /config/resources/
+COPY /src/main/liberty/config/jvmbx.options /config/jvm.options
+{{/javametrics}}
 {{/has}}
 {{#has buildType 'gradle'}}
 COPY /build/wlp/usr/servers/defaultServer /config/


### PR DESCRIPTION
I'm working to integrate javametrics https://github.com/RuntimeTools/javametrics into the liberty code gen and as such, need to modify the docker image to include the jvm options and javametrics data from the liberty codegen