### PR TITLE
Provide default values for region, org, and space

### DIFF
--- a/generators/cloudfoundry/templates/toolchain_master.yml
+++ b/generators/cloudfoundry/templates/toolchain_master.yml
@@ -48,3 +48,6 @@ deploy:
   service-category: pipeline
   parameters:
     app-name: {{name}}
+    dev-space: {{tag 'space'}}
+    dev-organization: {{tag 'organization'}}
+    dev-region: {{tag 'region'}}


### PR DESCRIPTION
If these values are not provided the validation in deploy.json will fail. This is not a problem and can be corrected when using the toolchain setup UI but unfortunately is an irrecoverable failure when toolchain creation is run headless.