### PR TITLE
Rename 'basic' to 'enable' for clarity

### DIFF
--- a/generators/cloudfoundry/index.js
+++ b/generators/cloudfoundry/index.js
@@ -89,7 +89,7 @@ module.exports = class extends Generator {
 		if (this.opts.createType === 'bff') {
 			this.manifestConfig.env.OPENAPI_SPEC = `/${this.name}/swagger/api`;
 		}
-		if (this.opts.createType && this.opts.createType.startsWith('basic/')) {
+		if (this.opts.createType && this.opts.createType.startsWith('enable/')) {
 			this.toolchainConfig.repoType = 'link';
 		}
 		this.pipelineConfig.triggersType = 'commit';

--- a/test/test-cloudfoundry.js
+++ b/test/test-cloudfoundry.js
@@ -88,7 +88,7 @@ describe('cloud-enablement:cloudfoundry', function () {
 	
 	let javaFrameworks = ['JAVA', 'SPRING'];
 	let javaBuildTypes = ['maven', 'gradle'];
-	let createTypes = ['basic/', 'microservice'];
+	let createTypes = ['enable/', 'microservice'];
 	
 	let assertYmlContent = function(actual, expected, label) {
 		assert.strictEqual(actual, expected, 'Expected ' + label + ' to be ' + expected + ', found ' + actual);
@@ -144,7 +144,7 @@ describe('cloud-enablement:cloudfoundry', function () {
 						assert.file('.bluemix/toolchain.yml');
 						let toolchainyml = yml.safeLoad(fs.readFileSync('.bluemix/toolchain.yml', 'utf8'));
 						let repoType = toolchainyml.repo.parameters.type;
-						if (createType === 'basic/') {
+						if (createType === 'enable/') {
 							assertYmlContent(repoType, 'link', 'toolchainyml.repo.type');
 						} else {
 							assertYmlContent(repoType, 'clone', 'toolchainyml.repo.type');


### PR DESCRIPTION
Renaming 'basic/' java generators to make the enable case more obvious
Signed-off-by: Erin Schnabel <schnabel@us.ibm.com>