### PR TITLE
Pipeline create-service commands

### DIFF
--- a/generators/cloudfoundry/index.js
+++ b/generators/cloudfoundry/index.js
@@ -31,7 +31,10 @@ module.exports = class extends Generator {
 		this.manifestConfig = {};
 		this.manifestConfig.env = {};
 		this.toolchainConfig = {};
-		this.pipelineConfig = {buildJobProps : {artifact_dir: "''"}};
+		this.pipelineConfig = {
+			buildJobProps : {artifact_dir: "''"},
+			services: this.bluemix.services
+		};
 		this.name = undefined
 		if(this.bluemix.server) {
 			this.name = this.bluemix.server.name;

--- a/generators/cloudfoundry/templates/pipeline_master.yml
+++ b/generators/cloudfoundry/templates/pipeline_master.yml
@@ -45,9 +45,9 @@ stages:
     script: |-
       #!/bin/bash
 {{#each services}}
-  # {{{@key}}}
-      cf create-service "{{{{label}}}}" "{{{{plan}}}}" "{{{{name}}}}"
-  # {{{/each}}}
+   {{#each this}}
+      cf create-service "{{{this.label}}}" "{{{this.plan}}}" "{{{this.name}}}"
+   {{/each}}
 {{/each}}
 {{#if pushCommand}}
       {{{pushCommand}}}

--- a/generators/cloudfoundry/templates/pipeline_master.yml
+++ b/generators/cloudfoundry/templates/pipeline_master.yml
@@ -44,6 +44,11 @@ stages:
       application: ${CF_APP}
     script: |-
       #!/bin/bash
+{{#each services}}
+  # {{{@key}}}
+      cf create-service "{{{{label}}}}" "{{{{plan}}}}" "{{{{name}}}}"
+  # {{{/each}}}
+{{/each}}
 {{#if pushCommand}}
       {{{pushCommand}}}
 {{else}}

--- a/test/samples/scaffolder-sample.js
+++ b/test/samples/scaffolder-sample.js
@@ -43,6 +43,18 @@ function get(language, bluemix) {
 	if(language === 'SPRING') {
 		bluemix.server.memory = "256M";
 	}
+	if(language === 'SWIFT') {
+		// The payload below simulates a short-term solution from generator-swiftserver
+		// which is used in the pipeline.yml create-service command.
+		bluemix.services = {
+			cloudant: [{
+				name: "gkghk-cloudantNo-1504851366275",
+				label: "cloudantNoSQLDB",
+				plan: "Lite",
+				credentials: {}
+			}]
+		};
+	}
 	return JSON.stringify(bluemix);
 }
 

--- a/test/test-cloudfoundry.js
+++ b/test/test-cloudfoundry.js
@@ -66,6 +66,11 @@ describe('cloud-enablement:cloudfoundry', function () {
 			assert.file('.bluemix/toolchain.yml');
 			assert.fileContent('.bluemix/toolchain.yml', 'type: clone');
 		});
+
+		/*it('pipeline.yml creates services', function () {
+			assert.file('.bluemix/pipeline.yml');
+			assert.fileContent('.bluemix/pipeline.yml', 'create-service');
+		});*/
 	});
 
 	describe('cloud-enablement:cloudfoundry with Node', function () {
@@ -85,11 +90,11 @@ describe('cloud-enablement:cloudfoundry', function () {
 			assert.fileContent('.bluemix/toolchain.yml', 'type: clone');
 		});
 	});
-	
+
 	let javaFrameworks = ['JAVA', 'SPRING'];
 	let javaBuildTypes = ['maven', 'gradle'];
 	let createTypes = ['enable/', 'microservice'];
-	
+
 	let assertYmlContent = function(actual, expected, label) {
 		assert.strictEqual(actual, expected, 'Expected ' + label + ' to be ' + expected + ', found ' + actual);
 	}
@@ -117,8 +122,8 @@ describe('cloud-enablement:cloudfoundry', function () {
 							assertYmlContent(manifestyml.applications[0].memory, '512M', 'manifestyml.applications[0].memory')
 							assertYmlContent(manifestyml.applications[0].buildpack, 'liberty-for-java', 'manifestyml.applications[0].buildpack')
 							assertYmlContent(manifestyml.applications[0].env.services_autoconfig_excludes, 'cloudantNoSQLDB=config Object-Storage=config', 'manifestyml.applications[0].env.services_autoconfig_excludes');
-						} 
-						
+						}
+
 						if ( language === 'SPRING' ) {
 							let targetDir = buildType === 'maven' ? 'target' : 'build/libs'
 							assertYmlContent(manifestyml.applications[0].path, './'+targetDir+'/my-application-'+javaVersion+'.jar', 'manifestyml.applications[0].path');

--- a/test/test-cloudfoundry.js
+++ b/test/test-cloudfoundry.js
@@ -67,10 +67,10 @@ describe('cloud-enablement:cloudfoundry', function () {
 			assert.fileContent('.bluemix/toolchain.yml', 'type: clone');
 		});
 
-		/*it('pipeline.yml creates services', function () {
+		it('pipeline.yml creates services', function () {
 			assert.file('.bluemix/pipeline.yml');
 			assert.fileContent('.bluemix/pipeline.yml', 'create-service');
-		});*/
+		});
 	});
 
 	describe('cloud-enablement:cloudfoundry with Node', function () {


### PR DESCRIPTION
This PR adds the final piece of functionality that **generator-swiftserver** needs in order to cut over to exclusively using **generator-ibm-cloud-enablement** for all Bluemix files.

As it currently stands, deployment using the deployment toolchain will fail on the first try in the *standalone use case*, as the services needed in the manifest and toolchain have not yet been created.  The command I have added here will account for this in a `bluemix.services` object, which is different from `bluemix.server.services` - the latter being an array of strings containing only the service instance names, which is insufficient for our use case.

This solution supports Swift at the current time, as it already leverages a `services` object using this format, Ultimately, we should reconcile this difference by standardizing the `services` object across all languages. 

## Constraints & Options

Unfortunately, using the raw spec from scaffolder in its current form is not an option - at the same level as the individual services are other flags and objects, such as `name` and `server` prevent it from being dynamically implemented.

+ Option 1: Ask scaffolder to provide us directly with a "services" object containing all of the services, at the same level as "name" and "server".  This structure of this object would need to be emulated in standalone cases.
+ Option 2: Parse the scaffolder payload for all languages in generator-ibm-cloud-enablement. This would result in less code duplication for every generator, but some generators would need other ways to determine which services are being used.
+ Option 3: Parse the scaffolder payload in the individual generators, and feed the manipulated payload to generator-swift server.  This gives languages more control over which services they support, but results in duplicated codebase, and difficulty ensuring adherence to standards.

I have added a test case, but left it commented out until we standardize how we can leverage this new functionality.

`bluemix.services` as passed by **generator-swiftserver**:
```
"services": {
    "cloudant": [
      {
        "name": "gkghk-cloudantNo-1504851366275",
        "label": "cloudantNoSQLDB",
        "plan": "Lite",
        "credentials": {
             ...
        }
      }
    ]
  },
```