### PR TITLE
Fix handlebars require in deployment subgenerator

### DIFF
--- a/generators/deployment/index.js
+++ b/generators/deployment/index.js
@@ -13,7 +13,7 @@
 
 'use strict';
 
-const Handlebars = require('handlebars');
+const Handlebars = require('../lib/helpers').handlebars;
 const Generator = require('yeoman-generator');
 const Utils = require('../lib/utils');
 


### PR DESCRIPTION
This is causing errors for generator-swiftserver as it may composeWith `deployment` only.
This problem won't show up if composeWith is used with `app` or one of the other subgenerators before `deployment`.