### PR TITLE
Use default domain if not set

### DIFF
--- a/generators/kubernetes/index.js
+++ b/generators/kubernetes/index.js
@@ -113,7 +113,8 @@ module.exports = class extends Generator {
 		if (this.bluemix.server) {
 			// TODO(gib): Can we get this from scaffolder (this.bluemix) somehow?
 			const namespace = this.bluemix.server.namespace ? this.bluemix.server.namespace : 'replace-me-namespace';
-			this.opts.repositoryURL= `registry.${this.bluemix.server.domain}/${namespace}/`;
+			const domain = this.bluemix.server.domain ? this.bluemix.server.domain : 'ng.bluemix.net';
+			this.opts.repositoryURL= `registry.${domain}/${namespace}/`;
 			this.opts.kubeClusterNamespace =
 				this.bluemix.server.cloudDeploymentOptions && this.bluemix.server.cloudDeploymentOptions.kubeClusterNamespace ?
 					this.bluemix.server.cloudDeploymentOptions.kubeClusterNamespace : 'default';


### PR DESCRIPTION
generator-swiftserver may pass no domain in the bluemix.server object when generating certain types of project in the prompting flow.