### PR TITLE
Kube deploy takes in registry token and sets imagePullSecret

### DIFF
--- a/generators/deployment/index.js
+++ b/generators/deployment/index.js
@@ -48,7 +48,9 @@ module.exports = class extends Generator {
 			this.deployment.containerScriptPath = '.bluemix/container_build.sh';
 			this.deployment.kubeDeployScriptName = 'kube_deploy.sh';
 			this.deployment.kubeDeployScriptPath = `.bluemix/${this.deployment.kubeDeployScriptName}`;
-
+			if (!this.deployment.kubeClusterNamespace) {
+				this.deployment.kubeClusterNamespace = 'default';
+			}
 		} else {
 			this.name = this.bluemix.name;
 			this.manifestConfig.name = this.bluemix.name;

--- a/generators/deployment/templates/container_build.sh
+++ b/generators/deployment/templates/container_build.sh
@@ -60,8 +60,10 @@ cp {{deployment.kubeDeployScriptPath}} $ARCHIVE_DIR/
 echo "IMAGE_NAME=${FULL_REPOSITORY_NAME}" >> $ARCHIVE_DIR/build.properties
 # RELEASE_NAME from build.properties is used in Helm Chart deployment to set the release name
 echo "RELEASE_NAME=${IMAGE_NAME}" >> $ARCHIVE_DIR/build.properties
+# REGISTRY_HOST from build.properties is used to create imagePullSecret, ex: registry.ng.bluemix.net
+echo "REGISTRY_HOST=${CCS_REGISTRY_HOST}" >> $ARCHIVE_DIR/build.properties
 
-CHART_PATH=./chart/{{deployment.name}}
+CHART_PATH=./chart/$IMAGE_NAME
 if [ -f ${CHART_PATH}/values.yaml ]; then
     #Update Helm chart values.yml with image name and tag
     echo "UPDATING CHART VALUES:"

--- a/generators/deployment/templates/deploy_master.json
+++ b/generators/deployment/templates/deploy_master.json
@@ -9,6 +9,14 @@
       "description": "The Bluemix API key is used to access the IBM Container Service API and interact with the cluster. You can obtain your API key with 'bx iam api-key-create' or via the console at https://console.bluemix.net/iam/#/apikeys by clicking **Create API key** (Each API key only can be viewed once).",
       "type": "string"
     },
+    "image-registry-token": {
+      "description": "Container Registry access token. Retrievable via [bx cr tokens]",
+      "type": "string"
+    },
+    "image-pull-secret-name": {
+      "description": "A name for the imagePullSecret which will reference the registry access token",
+      "type": "string"
+    },
     "kube-cluster-name": {
       "description": "Your cluster name. Retrieve it with [bx cs clusters] or via the console at https://console.bluemix.net/containers-kubernetes/home/clusters.",
       "type": "string"
@@ -31,7 +39,7 @@
       "type": "string"
     }
   },
-  "required": ["dev-region", "dev-organization", "dev-space", "app-name"{{#has deployment.type 'Kube'}}, "api-key", "kube-cluster-name"{{/has}}],
+  "required": ["dev-region", "dev-organization", "dev-space", "app-name"{{#has deployment.type 'Kube'}}, "api-key", "image-registry-token", "image-pull-secret-name", "kube-cluster-name"{{/has}}],
   "form": [{
     "type": "validator",
     "url": "/devops/setup/bm-helper/helper.html"
@@ -42,6 +50,16 @@
     "readonly": false,
     "title": "Bluemix API Key",
     "key": "api-key"
+  }, {
+    "type": "password",
+    "readonly": false,
+    "title": "Container Registry access token",
+    "key": "image-registry-token"
+  }, {
+    "type": "text",
+    "readonly": false,
+    "title": "Name for the imagePullSecret",
+    "key": "image-pull-secret-name"
   }, {
     "type": "text",
     "readonly": false,

--- a/generators/deployment/templates/kube_deploy.sh
+++ b/generators/deployment/templates/kube_deploy.sh
@@ -17,14 +17,14 @@ if ! kubectl get namespace $CLUSTER_NAMESPACE; then
     kubectl create namespace $CLUSTER_NAMESPACE
 fi
 
-# create imagePullSecret if it doesn't exist
+echo "create ${IMAGE_PULL_SECRET_NAME} imagePullSecret if it does not exist"
 if ! kubectl get secret ${IMAGE_PULL_SECRET_NAME} --namespace $CLUSTER_NAMESPACE; then
     echo "${IMAGE_PULL_SECRET_NAME} not found in $CLUSTER_NAMESPACE, creating it"
     # for Container Registry, docker username is 'token' and email does not matter
     kubectl --namespace $CLUSTER_NAMESPACE create secret docker-registry $IMAGE_PULL_SECRET_NAME --docker-server=$REGISTRY_HOST --docker-password=$IMAGE_REGISTRY_TOKEN --docker-username=token --docker-email=a@b.com
 fi
 
-# enable default serviceaccount to use the pull secret
+echo "enable default serviceaccount to use the pull secret"
 kubectl patch -n $CLUSTER_NAMESPACE serviceaccount/default -p '{"imagePullSecrets":[{"name":"'"$IMAGE_PULL_SECRET_NAME"'"}]}'
 echo "Namespace $CLUSTER_NAMESPACE is now authorized to pull from the private image registry"
 echo "default serviceAccount:"

--- a/generators/deployment/templates/kube_deploy.sh
+++ b/generators/deployment/templates/kube_deploy.sh
@@ -4,38 +4,67 @@
 #View build properties
 cat build.properties
 
-#Check cluster availability
+echo "Check cluster availability"
 ip_addr=$(bx cs workers $PIPELINE_KUBERNETES_CLUSTER_NAME | grep normal | awk '{ print $2 }')
 if [ -z $ip_addr ]; then
     echo "$PIPELINE_KUBERNETES_CLUSTER_NAME not created or workers not ready"
     exit 1
 fi
 
+echo "Check cluster target namespace"
+if ! kubectl get namespace $CLUSTER_NAMESPACE; then
+    echo "$CLUSTER_NAMESPACE cluster namespace does not exist, creating it"
+    kubectl create namespace $CLUSTER_NAMESPACE
+fi
+
+# create imagePullSecret if it doesn't exist
+if ! kubectl get secret ${IMAGE_PULL_SECRET_NAME} --namespace $CLUSTER_NAMESPACE; then
+    echo "${IMAGE_PULL_SECRET_NAME} not found in $CLUSTER_NAMESPACE, creating it"
+    # for Container Registry, docker username is 'token' and email does not matter
+    kubectl --namespace $CLUSTER_NAMESPACE create secret docker-registry $IMAGE_PULL_SECRET_NAME --docker-server=$REGISTRY_HOST --docker-password=$IMAGE_REGISTRY_TOKEN --docker-username=token --docker-email=a@b.com
+fi
+
+# enable default serviceaccount to use the pull secret
+kubectl patch -n $CLUSTER_NAMESPACE serviceaccount/default -p '{"imagePullSecrets":[{"name":"'"$IMAGE_PULL_SECRET_NAME"'"}]}'
+echo "Namespace $CLUSTER_NAMESPACE is now authorized to pull from the private image registry"
+echo "default serviceAccount:"
+kubectl get serviceAccount default -o yaml
+
 # Check Helm/Tiller
 echo "CHECKING TILLER (Helm's server component)"
 helm init --upgrade
 while true; do
-tiller_deployed=$(kubectl --namespace=kube-system get pods | grep tiller | grep Running | grep 1/1 )
-if [[ "${tiller_deployed}" != "" ]]; then
-    echo "Tiller ready."
-    break;
-fi
-echo "Waiting for Tiller to be ready."
-sleep 1
+    tiller_deployed=$(kubectl --namespace=kube-system get pods | grep tiller | grep Running | grep 1/1 )
+    if [[ "${tiller_deployed}" != "" ]]; then
+        echo "Tiller ready."
+        break;
+    fi
+    echo "Waiting for Tiller to be ready."
+    sleep 1
 done
+helm version
 
-echo "DEPLOYING..."
-CHART_NAME={{deployment.name}}
-helm upgrade ${RELEASE_NAME} ./chart/${CHART_NAME} --install --debug
+CHART_NAME=$RELEASE_NAME
+echo "CHART_NAME: $CHART_NAME"
+echo "RELEASE_NAME: $RELEASE_NAME"
+
+echo "CHECKING CHART (lint)"
+helm lint ${RELEASE_NAME} ./chart/${CHART_NAME}
+
+echo "DRY RUN DEPLOYING into: $PIPELINE_KUBERNETES_CLUSTER_NAME/$CLUSTER_NAMESPACE."
+helm upgrade ${RELEASE_NAME} ./chart/${CHART_NAME} --namespace $CLUSTER_NAMESPACE --install --debug --dry-run
+
+echo "DEPLOYING into: $PIPELINE_KUBERNETES_CLUSTER_NAME/$CLUSTER_NAMESPACE."
+helm upgrade ${RELEASE_NAME} ./chart/${CHART_NAME} --namespace $CLUSTER_NAMESPACE --install
 
 echo ""
 echo "DEPLOYED SERVICE:"
-kubectl describe services ${CHART_NAME}
+kubectl describe services ${CHART_NAME} --namespace $CLUSTER_NAMESPACE
 
 echo ""
 echo "DEPLOYED PODS:"
-kubectl describe pods --selector app=${CHART_NAME}-selector
+kubectl describe pods --selector app=${CHART_NAME}-selector --namespace $CLUSTER_NAMESPACE
 
-port=$(kubectl get services | grep ${CHART_NAME} | sed 's/.*:\([0-9]*\).*/\1/g')
+port=$(kubectl get services --namespace $CLUSTER_NAMESPACE | grep ${CHART_NAME} | sed 's/.*:\([0-9]*\).*/\1/g')
 echo ""
 echo "VIEW THE APPLICATION AT: http://$ip_addr:$port"

--- a/generators/deployment/templates/pipeline_master.yml
+++ b/generators/deployment/templates/pipeline_master.yml
@@ -47,10 +47,21 @@ stages:
   - type: job
     stage: Build Stage
     job: Build
+  {{#has deployment.type 'Kube'}}
   properties:
   - name: buildProperties
     value: build.properties
     type: file
+  - name: CLUSTER_NAMESPACE
+    value: {{deployment.kubeClusterNamespace}}
+    type: text
+  - name: IMAGE_PULL_SECRET_NAME
+    value: ${IMAGE_PULL_SECRET_NAME}
+    type: text
+  - name: IMAGE_REGISTRY_TOKEN
+    value: ${IMAGE_REGISTRY_TOKEN}
+    type: text
+  {{/has}}
   triggers:
   - type: stage
   jobs:

--- a/generators/deployment/templates/toolchain_master.yml
+++ b/generators/deployment/templates/toolchain_master.yml
@@ -36,6 +36,8 @@ build:
       {{#has deployment.type 'Kube'}}
       KUBE_CLUSTER_NAME: "{{tag 'deploy.parameters.kube-cluster-name'}}"
       API_KEY: "{{tag 'deploy.parameters.api-key'}}"
+      IMAGE_PULL_SECRET_NAME: "{{tag 'deploy.parameters.image-pull-secret-name'}}"
+      IMAGE_REGISTRY_TOKEN: "{{tag 'deploy.parameters.image-registry-token'}}"
       {{/has}}
      execute: true
     services: ["repo"]
@@ -58,4 +60,6 @@ deploy:
     {{#has deployment.type 'Kube'}}
     kube-cluster-name: {{deployment.kubeClusterName}}
     api-key: "{{tag 'api-key'}}"
+    image-pull-secret-name: "{{tag 'image-pull-secret-name'}}"
+    image-registry-token: "{{tag 'image-registry-token'}}"
     {{/has}}

--- a/test/samples/deploy-stage-properties.yaml
+++ b/test/samples/deploy-stage-properties.yaml
@@ -1,0 +1,12 @@
+- name: buildProperties
+  value: build.properties
+  type: file
+- name: CLUSTER_NAMESPACE
+  value: my_kube_namespace
+  type: text
+- name: IMAGE_PULL_SECRET_NAME
+  value: ${IMAGE_PULL_SECRET_NAME}
+  type: text
+- name: IMAGE_REGISTRY_TOKEN
+  value: ${IMAGE_REGISTRY_TOKEN}
+  type: text


### PR DESCRIPTION
Kube deploy job needs to have an `imagePullSecret` whose value is an image registry token to be able to pull images from image registry. When Kube cluster is created, there's no guarantee that this secret is automatically created and the token could be invalid.