### PR TITLE
ignore .build-ubuntu

### DIFF
--- a/generators/deployment/index.js
+++ b/generators/deployment/index.js
@@ -94,7 +94,7 @@ module.exports = class extends Generator {
 		this.manifestConfig.buildpack = 'swift_buildpack';
 		this.manifestConfig.command = this.name ? (`${this.name}`) : undefined;
 		this.manifestConfig.memory = this.manifestConfig.memory || '128M';
-		this.cfIgnoreContent = ['.build/*', 'Packages/*'];
+		this.cfIgnoreContent = ['.build/*', '.build-ubuntu/*', 'Packages/*'];
 	}
 
 	_configureJavaCommon() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "generator-ibm-cloud-enablement",
-	"version": "0.0.90",
+	"version": "0.0.91",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "generator-ibm-cloud-enablement",
-	"version": "0.0.89",
+	"version": "0.0.90",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "generator-ibm-cloud-enablement",
-	"version": "0.0.90",
+	"version": "0.0.91",
 	"description": "This generator adds IBM Cloud enablement to applications",
 	"main": "generators/app/index.js",
 	"license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "generator-ibm-cloud-enablement",
-	"version": "0.0.89",
+	"version": "0.0.90",
 	"description": "This generator adds IBM Cloud enablement to applications",
 	"main": "generators/app/index.js",
 	"license": "Apache-2.0",


### PR DESCRIPTION
This prevents a file permissions error in CF deploy for Swift.