### PR TITLE
Fix Deployment.yaml to use correct quotes and remove version selector

### DIFF
--- a/generators/kubernetes/templates/deployment.yaml
+++ b/generators/kubernetes/templates/deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: "{{tag '  .Chart.Name '}}-deployment"
   labels:
-    chart: "{{tag ' .Chart.Name '}}-{{{tag " .Chart.Version | replace '+' '_' "}}}"
+    chart: '{{tag ' .Chart.Name '}}-{{{tag ' .Chart.Version | replace "+" "_" '}}}'
 spec:
   replicas: {{tag ' .Values.replicaCount '}}
   revisionHistoryLimit: {{tag ' .Values.revisionHistoryLimit '}}

--- a/generators/kubernetes/templates/java/basedeployment.yaml
+++ b/generators/kubernetes/templates/java/basedeployment.yaml
@@ -4,7 +4,7 @@ kind: Deployment
 metadata:
   name: "{{tag '  .Chart.Name '}}-basedeployment"
   labels:
-    chart: "{{tag ' .Chart.Name '}}-{{{tag " .Chart.Version | replace '+' '_' "}}}"
+    chart: '{{tag ' .Chart.Name '}}-{{{tag ' .Chart.Version | replace "+" "_" '}}}'
 spec:
   replicas: {{tag ' .Values.base.replicaCount '}}
   revisionHistoryLimit: {{tag ' .Values.revisionHistoryLimit '}}
@@ -12,7 +12,6 @@ spec:
     metadata:
       labels:
         app: "{{tag '  .Chart.Name '}}-selector"
-        version: "base"
     spec:
       containers:
       - name: "{{tag '  .Chart.Name  '}}"

--- a/generators/kubernetes/templates/java/deployment.yaml
+++ b/generators/kubernetes/templates/java/deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: "{{tag '  .Chart.Name '}}-deployment"
   labels:
-    chart: "{{tag ' .Chart.Name '}}-{{{tag " .Chart.Version | replace '+' '_' "}}}"
+    chart: '{{tag ' .Chart.Name '}}-{{{tag ' .Chart.Version | replace "+" "_" '}}}'
 spec:
   replicas: {{tag ' .Values.replicaCount '}}
   revisionHistoryLimit: {{tag ' .Values.revisionHistoryLimit '}}
@@ -11,7 +11,6 @@ spec:
     metadata:
       labels:
         app: "{{tag '  .Chart.Name '}}-selector"
-        version: "current"
     spec:
       containers:
       - name: "{{tag '  .Chart.Name  '}}"

--- a/test/samples/deployment-with-mongo-java.yaml
+++ b/test/samples/deployment-with-mongo-java.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: "{{  .Chart.Name }}-deployment"
   labels:
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace '+' '_' }}"
+    chart: '{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}'
 spec:
   replicas: {{ .Values.replicaCount }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
@@ -11,7 +11,6 @@ spec:
     metadata:
       labels:
         app: "{{  .Chart.Name }}-selector"
-        version: "current"
     spec:
       containers:
       - name: "{{  .Chart.Name  }}"

--- a/test/samples/deployment-with-mongo.yaml
+++ b/test/samples/deployment-with-mongo.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: "{{  .Chart.Name }}-deployment"
   labels:
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace '+' '_' }}"
+    chart: '{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}'
 spec:
   replicas: {{ .Values.replicaCount }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}


### PR DESCRIPTION
Needs double quotes around strings for replace function in Deployment.yaml,
else will fail helm lint. Remove version in selector, else won't be able
to make changes and upgrade deployed app because now the version label will
be different between new version and currently deployed version.