### PR TITLE
Added rolling update strategy to kubernetes deployment.

### DIFF
--- a/generators/kubernetes/templates/deployment.yaml
+++ b/generators/kubernetes/templates/deployment.yaml
@@ -6,6 +6,11 @@ metadata:
     chart: '{{tag ' .Chart.Name '}}-{{{tag ' .Chart.Version | replace "+" "_" '}}}'
 spec:
   replicas: {{tag ' .Values.replicaCount '}}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
   revisionHistoryLimit: {{tag ' .Values.revisionHistoryLimit '}}
   template:
     metadata:

--- a/test/samples/deployment-with-mongo.yaml
+++ b/test/samples/deployment-with-mongo.yaml
@@ -6,6 +6,11 @@ metadata:
     chart: '{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}'
 spec:
   replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   template:
     metadata:


### PR DESCRIPTION
This is required in order to make helm install “—wait” flag to work
properly and wait until pods are actually ready.