### PR TITLE
fix: install libxml2 library to docker image if dashDB service is sel…

### DIFF
--- a/generators/dockertools/index.js
+++ b/generators/dockertools/index.js
@@ -153,6 +153,23 @@ module.exports = class extends Generator {
 		const applicationName = Utils.sanitizeAlphaNum(this.bluemix.name);
 		const port = this.opts.port ? this.opts.port : '3000';
 
+		// Define metadata for all services that
+		// require custom logic in Dockerfiles
+		const services = require('./resources/node/services.json');
+
+		// Get array with all the keys for the services objects
+		const servKeys = Object.keys(services);
+		const servicesPackages = [];
+
+		// Iterate over service keys to search for provisioned services
+		for (let index in servKeys) {
+			const servKey = servKeys[index];
+			if (this.bluemix.hasOwnProperty(servKey)) {
+				if (services[servKey].package) {
+					servicesPackages.push(services[servKey].package);
+				}
+			}
+		}
 
 		const cliConfig = {
 			containerNameRun: `${applicationName.toLowerCase()}-express-run`,
@@ -193,6 +210,7 @@ module.exports = class extends Generator {
 				this.templatePath('node/Dockerfile'),
 				this.destinationPath(FILENAME_DOCKERFILE), {
 					port: port,
+					servicesPackages: servicesPackages
 				}
 			);
 		}

--- a/generators/dockertools/resources/node/services.json
+++ b/generators/dockertools/resources/node/services.json
@@ -1,0 +1,5 @@
+{
+  "dashDb": {
+    "package": "libxml2"
+  }
+}

--- a/generators/dockertools/templates/node/Dockerfile
+++ b/generators/dockertools/templates/node/Dockerfile
@@ -9,5 +9,10 @@ EXPOSE <%= port %>
 
 WORKDIR "/app"
 
+RUN apt-get update \
+<% for (var index = 0; index < servicesPackages.length; index++) { -%>
+ && apt-get install -y <%- servicesPackages[index] %> \
+<% } -%>
+ && echo 'Finished installing dependencies'
 RUN npm install
 CMD ["npm", "start"]

--- a/test/samples/scaffolder-sample-contents.js
+++ b/test/samples/scaffolder-sample-contents.js
@@ -79,6 +79,25 @@ class scaffolderSample {
 				"url": "https://gateway.watsonplatform.net/conversation/api",
 				"username": "0ec0f025-54r2-4e84-944f-8224a66217f2"
 			},
+			"dashDb": {
+				"db": "BLUDB",
+				"dsn": "DATABASE=BLUDB;HOSTNAME=ys1-dashdb-small-bm01-im-dal06-env4.services.dal.bluemix.net;PORT=50000;PROTOCOL=TCPIP;UID=dash105642;PWD=_qFv_9yCH8Al;",
+				"host": "ys1-dashdb-small-bm01-im-dal06-env4.services.dal.bluemix.net",
+				"hostname": "ys1-dashdb-small-bm01-im-dal06-env4.services.dal.bluemix.net",
+				"https_url": "https://ys1-dashdb-small-bm01-im-dal06-env4.services.dal.bluemix.net:8443",
+				"jdbcurl": "jdbc:db2://ys1-dashdb-small-bm01-im-dal06-env4.services.dal.bluemix.net:50000/BLUDB",
+				"password": "_qFv_9yCH8Al",
+				"port": 50000,
+				"serviceInfo": {
+					"label": "MyAnalyticsLabel",
+					"name": "MyAnalyticsService",
+					"plan": "Basic"
+				},
+				"ssldsn": "DATABASE=BLUDB;HOSTNAME=ys1-dashdb-small-bm01-im-dal06-env4.services.dal.bluemix.net;PORT=50001;PROTOCOL=TCPIP;UID=dash105642;PWD=_qFv_9yCH8Al;Security=SSL;",
+				"ssljdbcurl": "jdbc:db2://ys1-dashdb-small-bm01-im-dal06-env4.services.dal.bluemix.net:50001/BLUDB:sslConnection=true;",
+				"uri": "db2://dash105642:_qFv_9yCH8Al@ys1-dashdb-small-bm01-im-dal06-env4.services.dal.bluemix.net:50000/BLUDB",
+				"username": "dash105642"
+			},
 			"discovery": {
 				"password": "IDgoZXBCGsDe",
 				"serviceInfo": {
@@ -312,4 +331,4 @@ class scaffolderSample {
 
 module.exports = {
 	scaffolderSample : scaffolderSample
-}
+};

--- a/test/samples/scaffolder-sample.js
+++ b/test/samples/scaffolder-sample.js
@@ -69,4 +69,4 @@ module.exports = {
 	getJsonNoServices : getJsonNoServices,
 	getJsonNoServer : getJsonNoServer,
 	getJsonServerWithDeployment: getJsonServerWithDeployment
-}
+};

--- a/test/test-dockertools.js
+++ b/test/test-dockertools.js
@@ -141,6 +141,19 @@ describe('cloud-enablement:dockertools', function () {
 		});
 	});
 
+	describe('cloud-enablement:dockertools with NodeJS project with dashDB', function () {
+		beforeEach(function () {
+			return helpers.run(path.join(__dirname, '../generators/app'))
+				.inDir(path.join(__dirname, './tmp'))
+				.withOptions({bluemix: JSON.stringify(scaffolderSampleNode)})
+		});
+
+		it('create Dockerfile for running', function () {
+			assert.file(['Dockerfile', 'cli-config.yml', 'Dockerfile-tools']);
+			assert.fileContent('Dockerfile', '&& apt-get install -y libxml2 \\');
+		});
+	});
+
 	/* Common Java Project characteristics: Spring or Liberty, maven or gradle */
 	let javaBuildTypes = ['maven', 'gradle'];
 	let javaFrameworks = ['JAVA', 'SPRING'];
@@ -327,7 +340,7 @@ describe('cloud-enablement:dockertools', function () {
 
 		it('create Dockerfile-tools with flask', function () {
 			assert.file(['Dockerfile-tools']);
-		})
+		});
 
 		it('create CLI-config file', function () {
 			assert.file(['cli-config.yml']);
@@ -360,7 +373,7 @@ describe('cloud-enablement:dockertools', function () {
 
 		it('create Dockerfile-tools with flask', function () {
 			assert.file(['Dockerfile-tools']);
-		})
+		});
 
 		it('create CLI-config file with informative echo prompt', function () {
 			assert.file(['cli-config.yml']);
@@ -454,7 +467,7 @@ describe('cloud-enablement:dockertools', function () {
 
 		it('create Dockerfile-tools with flask', function () {
 			assert.file(['Dockerfile-tools']);
-		})
+		});
 
 		it('create CLI-config file', function () {
 			assert.file(['cli-config.yml']);


### PR DESCRIPTION
…ected

Adding the `dashDB` service results in this error after performing a `bx dev build && bx dev run`:

```
[INFO] ibm-cloud-env - Initializing with /app/server/config/mappings.json
/app/node_modules/bindings/bindings.js:83
        throw e
        ^

Error: libxml2.so.2: cannot open shared object file: No such file or directory
    at Error (native)
    at Object.Module._extensions..node (module.js:597:18)
    at Module.load (module.js:487:32)
    at tryModuleLoad (module.js:446:12)
    at Function.Module._load (module.js:438:3)
    at Module.require (module.js:497:17)
    at Module.newFunc (/app/node_modules/appmetrics/lib/aspect.js:101:26)
    at require (internal/module.js:20:19)
    at bindings (/app/node_modules/bindings/bindings.js:76:44)
    at Object.<anonymous> (/app/node_modules/ibm_db/lib/odbc.js:31:31)
```

We need to install the `libxml2` library and add it to the **Dockerfile** for Node to avoid this error. I tried to be consistent with the other parts of the code, but let me know if I did this correctly / any other updates need to be made.

Thanks!