### PR TITLE
feat: Added manage.py file for Python Starters

### DIFF
--- a/generators/deployment/index.js
+++ b/generators/deployment/index.js
@@ -178,7 +178,7 @@ module.exports = class extends Generator {
 		this.manifestConfig.buildpack = 'python_buildpack';
 		this.manifestConfig.command = this.opts.enable
 			? 'echo No run command specified in manifest.yml'
-			: 'gunicorn server:app -b 0.0.0.0:$PORT';
+			: 'python manage.py start 0.0.0.0:$PORT';
 		this.manifestConfig.memory = this.manifestConfig.memory || '128M';
 		this.manifestConfig.env.FLASK_APP = 'server';
 		this.manifestConfig.env.FLASK_DEBUG = 'true';

--- a/generators/dockertools/index.js
+++ b/generators/dockertools/index.js
@@ -310,16 +310,16 @@ module.exports = class extends Generator {
 			dockerFileTools: 'Dockerfile-tools',
 			imageNameRun: `${applicationName.toLowerCase()}-flask-run`,
 			imageNameTools: `${applicationName.toLowerCase()}-flask-tools`,
-			buildCmdRun: 'python -m compileall .',
+			buildCmdRun: 'python manage.py build',
 			testCmd: this.opts.enable
 				? 'echo No test command specified in cli-config'
-				: 'python -m unittest tests.app_tests.ServerTestCase',
-			buildCmdDebug: 'python -m compileall .',
+				: 'python manage.py test',
+			buildCmdDebug: 'python manage.py build',
 			runCmd: '',
 			stopCmd: '',
 			debugCmd: this.opts.enable
 				? 'echo No debug command specified in cli-config'
-				: 'python -m flask run --host=0.0.0.0 --port=5858 --debugger',
+				: 'python manage.py debug',
 			chartPath: `chart/${applicationName.toLowerCase()}`
 		};
 
@@ -356,6 +356,18 @@ module.exports = class extends Generator {
 					servicesPackages: servicesPackages
 				}
 			);
+		}
+
+		const FILENAME_MANAGEMENT = "manage.py";
+		if (!this.opts.enable) {
+			if (this.fs.exists(this.destinationPath(FILENAME_MANAGEMENT))){
+				console.info(FILENAME_MANAGEMENT, "already exists, skipping.");
+			} else {
+				this.fs.copy(
+					this.templatePath('python/manage.py'),
+					this.destinationPath(FILENAME_MANAGEMENT)
+				);
+			}
 		}
 
 		this.fs.copy(

--- a/generators/dockertools/templates/python/Dockerfile
+++ b/generators/dockertools/templates/python/Dockerfile
@@ -20,5 +20,5 @@ ENV FLASK_APP=server
 <% if (enable) { %>
 CMD ["echo", "No run command specified in Dockerfile"]
 <% } else { %>
-CMD ["gunicorn", "-b", "0.0.0.0:<%= port %>", "server:app"]
+CMD ["python", "manage.py", "start", "0.0.0.0:<%= port %>"]
 <% } %>

--- a/generators/dockertools/templates/python/manage.py
+++ b/generators/dockertools/templates/python/manage.py
@@ -1,0 +1,115 @@
+import os, sys, argparse, subprocess
+
+# Project defaults
+FLASK_APP = 'server'
+DEFAULT_IP = '0.0.0.0:3000'
+
+class Command:
+	def __init__(self, name, descr, runcmd, env={}):
+		self.name = name
+		self.descr = descr
+		self.runcmd = runcmd
+		self.env = env
+
+	def run(self, conf):
+		cmd = self.runcmd(conf)
+		env = os.environ
+		env.update(conf)
+		env.update(self.env)
+		subprocess.call(cmd, env=env, shell=True)
+
+class CommandManager:
+	def __init__(self):
+		self.commands = {}
+
+	def add(self, command):
+		self.commands[command.name] = command
+
+	def configure(self, conf):
+		self.conf = conf
+
+	def run(self, command):
+		if command in self.commands:
+			self.commands[command].run(self.conf)
+		else:
+			print("invalid command specified\n")
+			print(self.availableCommands())
+
+	def availableCommands(self):
+		commands = sorted(self.commands.values(), key=lambda c: c.name)
+		space = max([len(c.name) for c in commands]) + 2
+		description = 'available subcommands:\n'
+		for c in commands:
+			description += '  ' + c.name + ' ' * (space - len(c.name)) + c.descr + '\n'
+		return description
+
+cm = CommandManager()
+
+cm.add(Command(
+	"build",
+	"compiles python files in project into .pyc binaries",
+	lambda c: 'python -m compileall .'))
+
+cm.add(Command(
+	"start",
+	"runs server with gunicorn in a production setting",
+	lambda c: 'gunicorn -b {0}:{1} server:app'.format(c['host'], c['port']),
+	{
+		'FLASK_APP': FLASK_APP,
+		'FLASK_DEBUG': 'false'
+	}))
+
+cm.add(Command(
+	"runserver",
+	"runs dev server using Flask's native debugger & backend reloader",
+	lambda c: 'python -m flask run --host={0} --port={1} --debugger --reload'.format(c['host'], c['port']),
+	{
+		'FLASK_APP': FLASK_APP,
+		'FLASK_DEBUG': 'true'
+	}))
+
+cm.add(Command(
+	"livereload",
+	"runs dev server using livereload for dynamic webpage reloading",
+	lambda c: 'python -m flask run',
+	{
+		'FLASK_APP': FLASK_APP,
+		'FLASK_LIVE_RELOAD': 'true',
+	}))
+
+cm.add(Command(
+	"debug",
+	"runs dev server in debug mode; use with an IDE's remote debugger",
+	lambda c: 'python -m flask run --host={0} --port={1} --no-debugger --no-reload'.format(c['host'], c['port']),
+	{
+		'FLASK_APP': FLASK_APP,
+		'FLASK_DEBUG': 'true'
+	}))
+
+cm.add(Command(
+	"test",
+	"runs all tests inside of `tests` directory",
+	lambda c: 'python -m unittest discover -s tests -p "*.py"'))
+
+# Create and format argument parser for CLI
+parser = argparse.ArgumentParser(description=cm.availableCommands(),
+								 formatter_class=argparse.RawDescriptionHelpFormatter)
+parser.add_argument("subcommand", help="subcommand to run (see list above)")
+parser.add_argument("ipaddress", nargs='?', default=DEFAULT_IP,
+					help="address and port to run on (i.e. {0})".format(DEFAULT_IP))
+
+# Take in command line input for configuration
+try:
+	args = parser.parse_args()
+	cmd = args.subcommand
+	addr = args.ipaddress.split(':')
+	cm.configure({
+		'host': addr[0],
+		'port': addr[1],
+	})
+except:
+	if len(sys.argv) == 1:
+		print(cm.availableCommands())
+	sys.exit(0)
+else:
+	cm.run(cmd)

--- a/test/test-dockertools.js
+++ b/test/test-dockertools.js
@@ -320,9 +320,9 @@ describe('cloud-enablement:dockertools', function () {
 				.withOptions({bluemix: JSON.stringify(scaffolderSamplePython)})
 		});
 
-		it('create Dockerfile with gunicorn', function () {
+		it('create Dockerfile with start command', function () {
 			assert.file(['Dockerfile']);
-			assert.fileContent('Dockerfile', 'gunicorn');
+			assert.fileContent('Dockerfile', '"python", "manage.py", "start"');
 		});
 
 		it('create Dockerfile-tools with flask', function () {
@@ -331,10 +331,15 @@ describe('cloud-enablement:dockertools', function () {
 
 		it('create CLI-config file', function () {
 			assert.file(['cli-config.yml']);
-			assert.fileContent('cli-config.yml', 'flask run');
+			assert.fileContent('cli-config.yml', 'python manage.py');
 			assert.fileContent('cli-config.yml', 'acmeproject-flask-run');
 			assert.fileContent('cli-config.yml', `chart-path : "chart/${applicationName.toLowerCase()}"`);
 		});
+
+		it('create manage.py file for flask', function () {
+			assert.file(['manage.py']);
+			assert.fileContent('manage.py', 'flask run');
+		})
 
 		it('create dockerignore file', function () {
 			assert.file([
@@ -369,6 +374,10 @@ describe('cloud-enablement:dockertools', function () {
 			assert.fileContent('cli-config.yml', `chart-path : "chart/${applicationName.toLowerCase()}"`);
 		});
 
+		it('does not create manage.py file for flask', function () {
+			assert.noFile(['manage.py']);
+		})
+
 		it('create dockerignore file', function () {
 			assert.file([
 				'.dockerignore'
@@ -383,9 +392,9 @@ describe('cloud-enablement:dockertools', function () {
 				.withOptions({bluemix: JSON.stringify(scaffolderSamplePythonNoServices)})
 		});
 
-		it('create Dockerfile with gunicorn and service package', function () {
+		it('create Dockerfile with start command and service package', function () {
 			assert.file(['Dockerfile']);
-			assert.fileContent('Dockerfile', 'gunicorn');
+			assert.fileContent('Dockerfile', '"python", "manage.py", "start"');
 			assert.noFileContent('Dockerfile', 'postgresql-dev \\');
 		});
 
@@ -396,10 +405,15 @@ describe('cloud-enablement:dockertools', function () {
 
 		it('create CLI-config file', function () {
 			assert.file(['cli-config.yml']);
-			assert.fileContent('cli-config.yml', 'flask run');
+			assert.fileContent('cli-config.yml', 'python manage.py');
 			assert.fileContent('cli-config.yml', 'acmeproject-flask-run');
 			assert.fileContent('cli-config.yml', `chart-path : "chart/${applicationName.toLowerCase()}"`);
 		});
+
+		it('create manage.py file for flask', function () {
+			assert.file(['manage.py']);
+			assert.fileContent('manage.py', 'flask run');
+		})
 
 		it('create dockerignore file', function () {
 			assert.file([
@@ -415,9 +429,9 @@ describe('cloud-enablement:dockertools', function () {
 				.withOptions({bluemix: JSON.stringify(scaffolderSamplePython)})
 		});
 
-		it('create Dockerfile with gunicorn and service package', function () {
+		it('create Dockerfile with start command and service package', function () {
 			assert.file(['Dockerfile']);
-			assert.fileContent('Dockerfile', 'gunicorn');
+			assert.fileContent('Dockerfile', '"python", "manage.py", "start"');
 			assert.fileContent('Dockerfile', 'postgresql-dev \\');
 		});
 
@@ -428,10 +442,15 @@ describe('cloud-enablement:dockertools', function () {
 
 		it('create CLI-config file', function () {
 			assert.file(['cli-config.yml']);
-			assert.fileContent('cli-config.yml', 'flask run');
+			assert.fileContent('cli-config.yml', 'python manage.py');
 			assert.fileContent('cli-config.yml', 'acmeproject-flask-run');
 			assert.fileContent('cli-config.yml', `chart-path : "chart/${applicationName.toLowerCase()}"`);
 		});
+
+		it('create manage.py file for flask', function () {
+			assert.file(['manage.py']);
+			assert.fileContent('manage.py', 'flask run');
+		})
 
 		it('create dockerignore file', function () {
 			assert.file([
@@ -447,9 +466,9 @@ describe('cloud-enablement:dockertools', function () {
 				.withOptions({bluemix: JSON.stringify(scaffolderSamplePython)})
 		});
 
-		it('create Dockerfile with gunicorn', function () {
+		it('create Dockerfile with start command', function () {
 			assert.file(['Dockerfile']);
-			assert.fileContent('Dockerfile', 'gunicorn');
+			assert.fileContent('Dockerfile', '"python", "manage.py", "start"');
 		});
 
 		it('create Dockerfile-tools with flask', function () {
@@ -458,10 +477,15 @@ describe('cloud-enablement:dockertools', function () {
 
 		it('create CLI-config file', function () {
 			assert.file(['cli-config.yml']);
-			assert.fileContent('cli-config.yml', 'flask run');
+			assert.fileContent('cli-config.yml', 'python manage.py');
 			assert.fileContent('cli-config.yml', 'acmeproject-flask-run');
 			assert.fileContent('cli-config.yml', `chart-path : "chart/${applicationName.toLowerCase()}"`);
 		});
+
+		it('create manage.py file for flask', function () {
+			assert.file(['manage.py']);
+			assert.fileContent('manage.py', 'flask run');
+		})
 
 		it('create dockerignore file', function () {
 			assert.file([


### PR DESCRIPTION
`manage.py` exists to create a unified set of commands between python
projects. For Flask, it will make starting apps and running commands
easier locally and give an alternative to using `idt`. The run-commands
of several files have been updated to now integrate with `manage.py`.