### PR TITLE
fix: Prevent python apps from deploying in debug mode

### DIFF
--- a/generators/deployment/index.js
+++ b/generators/deployment/index.js
@@ -181,7 +181,7 @@ module.exports = class extends Generator {
 			: 'python manage.py start 0.0.0.0:$PORT';
 		this.manifestConfig.memory = this.manifestConfig.memory || '128M';
 		this.manifestConfig.env.FLASK_APP = 'server';
-		this.manifestConfig.env.FLASK_DEBUG = 'true';
+		this.manifestConfig.env.FLASK_DEBUG = 'false';
 		this.cfIgnoreContent = ['.pyc', '.egg-info'];
 	}
 


### PR DESCRIPTION
`FLASK_DEBUG` should never be true when a user is deploying an app to
the cloud. The `manifest.yml` file is being updated appropriately.

(Note: With the introduction of `manage.py`, this should no longer make
a difference, but this is a fix that needs to be made anyway)