### PR TITLE
fix: move composeWith from init to config

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -32,9 +32,6 @@ module.exports = class extends Generator {
 	}
 
 	initializing() {
-		this.composeWith(require.resolve('../dockertools'), this.opts);
-		this.composeWith(require.resolve('../kubernetes'), this.opts);
-		this.composeWith(require.resolve('../deployment'), this.opts);
 	}
 
 	prompting() {
@@ -85,6 +82,9 @@ module.exports = class extends Generator {
 	}
 
 	configuring() {
+		this.composeWith(require.resolve('../dockertools'), this.opts);
+		this.composeWith(require.resolve('../kubernetes'), this.opts);
+		this.composeWith(require.resolve('../deployment'), this.opts);
 	}
 
 	_processAnswers(answers) {


### PR DESCRIPTION
Move composeWith call into configuring method so that the opts with the correct values is passed into it.  This change make "yo ibm-cloud-enablement" works locally without --blumix.