### PR TITLE
feat: Adding Prometheus support for Kubernetes on Python Flask starters

### DIFF
--- a/generators/kubernetes/index.js
+++ b/generators/kubernetes/index.js
@@ -39,7 +39,8 @@ const portDefault = {
 		http: '3000'
 	},
 	python: {
-		http: '3000'
+		http: '3000',
+		prometheus: '9000'
 	},
 	swift: {
 		http: '8080'
@@ -79,7 +80,7 @@ module.exports = class extends Generator {
 			istio: {source : 'istio.yaml', target : 'chartDir/templates/istio.yaml', process: true},
 			basedeployment: {source : 'basedeployment.yaml', target : 'chartDir/templates/basedeployment.yaml', process: true},
 			values: {source : 'values.yaml', target : 'chartDir/values.yaml', process: true}
-		}
+		};
 	}
 
 	configuring() {
@@ -156,8 +157,8 @@ module.exports = class extends Generator {
 				target : 'Jenkinsfile',
 				process : true
 			}
-		// Handle Java and Spring
-		} else if (this.opts.language === 'java' || this.opts.language === 'spring') {
+		}
+		else if (this.opts.language === 'java' || this.opts.language === 'spring') {
 			this.fileLocations.deployment.source = 'java/deployment.yaml';
 			this.fileLocations.basedeployment.source = 'java/basedeployment.yaml';
 			this.fileLocations.service.source = 'java/service.yaml';
@@ -167,12 +168,17 @@ module.exports = class extends Generator {
 				source : 'java/manifests/kube.deploy.yml',
 				target : 'manifests/kube.deploy.yml',
 				process : true
-			}
+			};
 			this.fileLocations.jenkinsfile = {
 				source : 'java/Jenkinsfile',
 				target : 'Jenkinsfile',
 				process : true
-			}
+			};
+		}
+		else if (this.opts.language === 'python') {
+			this.fileLocations.promConfig = {source : 'python/prometheus/prometheus-config.yaml', target : 'chartDir/templates/prometheus/prometheus-config.yaml', process: true};
+			this.fileLocations.promDeploy = {source : 'python/prometheus/prometheus-deployment.yaml', target : 'chartDir/templates/prometheus/prometheus-deployment.yaml', process: true};
+			this.fileLocations.promService = {source : 'python/prometheus/prometheus-service.yaml', target : 'chartDir/templates/prometheus/prometheus-service.yaml', process: true};
 		}
 
 		// iterate over file names

--- a/generators/kubernetes/templates/deployment.yaml
+++ b/generators/kubernetes/templates/deployment.yaml
@@ -28,6 +28,8 @@ spec:
             port: {{tag ' .Values.service.servicePort '}}
           initialDelaySeconds: {{tag ' .Values.livenessProbe.initialDelaySeconds'}}
           periodSeconds: {{tag ' .Values.livenessProbe.periodSeconds'}}
+        ports:
+        - containerPort: {{tag ' .Values.service.servicePort'}}
         resources:
           requests:
             cpu: "{{tag ' .Values.image.resources.requests.cpu '}}"

--- a/generators/kubernetes/templates/python/prometheus/prometheus-config.yaml
+++ b/generators/kubernetes/templates/python/prometheus/prometheus-config.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-config
+  labels:
+    chart: "{{tag ' .Chart.Name'}}-{{tag ' .Chart.Version'}}"
+    heritage: "{{tag ' .Release.Service'}}"
+    release: "{{tag ' .Release.Name'}}"
+    app: "{{tag ' .Chart.Name'}}-selector"
+data:
+  prometheus.yml: |
+    global:
+      scrape_interval: 5s
+      evaluation_interval: 5s
+    scrape_configs:
+      - job_name: 'prometheus'
+        static_configs:
+          - targets: ['localhost:{{servicePorts.prometheus}}']
+      - job_name: "{{tag ' .Chart.Name'}}-selector"
+        kubernetes_sd_configs:
+          - role: pod
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_pod_label_app]
+            regex: "{{tag ' .Chart.Name'}}-selector"
+            action: keep

--- a/generators/kubernetes/templates/python/prometheus/prometheus-deployment.yaml
+++ b/generators/kubernetes/templates/python/prometheus/prometheus-deployment.yaml
@@ -1,0 +1,30 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: prometheus-deployment
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: prometheus-server
+    spec:
+      containers:
+        - name: prometheus
+          image: prom/prometheus:v1.8.2
+          args:
+            - "-config.file=/etc/prometheus/conf/prometheus.yml"
+            - "-storage.local.path=/prometheus/"
+          ports:
+            - containerPort: {{servicePorts.prometheus}}
+          volumeMounts:
+            - name: prometheus-config-volume
+              mountPath: /etc/prometheus/conf/
+            - name: prometheus-storage-volume
+              mountPath: /prometheus/
+      volumes:
+        - name: prometheus-config-volume
+          configMap:
+            name: prometheus-config
+        - name: prometheus-storage-volume
+          emptyDir: {}

--- a/generators/kubernetes/templates/python/prometheus/prometheus-service.yaml
+++ b/generators/kubernetes/templates/python/prometheus/prometheus-service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus-service
+spec:
+  selector:
+    app: prometheus-server
+  type: NodePort
+  ports:
+    - port: 80
+      targetPort: {{servicePorts.prometheus}}

--- a/test/samples/deployment-with-mongo.yaml
+++ b/test/samples/deployment-with-mongo.yaml
@@ -28,6 +28,8 @@ spec:
             port: {{ .Values.service.servicePort }}
           initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds}}
           periodSeconds: {{ .Values.livenessProbe.periodSeconds}}
+        ports:
+        - containerPort: {{ .Values.service.servicePort}}
         resources:
           requests:
             cpu: "{{ .Values.image.resources.requests.cpu }}"

--- a/test/test-kubernetes.js
+++ b/test/test-kubernetes.js
@@ -446,6 +446,15 @@ describe('cloud-enablement:kubernetes', function () {
 		});
 
 		testOutput();
+
+		it('Python has Prometheus configuration with correct content', function () {
+			let promConfig = yml.safeLoad(fs.readFileSync(chartLocation + '/templates/prometheus/prometheus-config.yaml', 'utf8'));
+			let promDeploy = yml.safeLoad(fs.readFileSync(chartLocation + '/templates/prometheus/prometheus-deployment.yaml', 'utf8'));
+			let promService = yml.safeLoad(fs.readFileSync(chartLocation + '/templates/prometheus/prometheus-service.yaml', 'utf8'));
+			assertYmlContent(promConfig.kind, 'ConfigMap', 'promConfig.kind');
+			assertYmlContent(promDeploy.kind, 'Deployment', 'promDeploy.kind');
+			assertYmlContent(promService.kind, 'Service', 'promService.kind');
+		});
 	});
 
 	describe('kubernetes:app with Python project and mongo deployment', function () {


### PR DESCRIPTION
This PR adds additional charts to Flask Starter’s helm charts to
support the integration of a Prometheus Server to scrape the actual
starter as a remote pod/service.