### PR TITLE
fix:node for istio support

### DIFF
--- a/generators/kubernetes/templates/service.yaml
+++ b/generators/kubernetes/templates/service.yaml
@@ -3,12 +3,13 @@ kind: Service
 metadata:
   annotations:
     prometheus.io/scrape: 'true'
-  name: "{{  .Chart.Name }}"
+  name: "{{  .Chart.Name }}-service"
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 spec:
   type: {{ .Values.service.type }}
   ports:
-  - port: {{ .Values.service.servicePort }}
+  - name: http  
+    port: {{ .Values.service.servicePort }}
   selector:
     app: "{{  .Chart.Name }}-selector"


### PR DESCRIPTION
Add "-service" to the node service name for consistency across languages and add the name attribute "http" to the node service port that is required by Istio.