### PR TITLE
fix(templates): Fix bx dev build failure for java app in Windows 10

### DIFF
--- a/generators/dockertools/templates/java/cli-config.yml.template
+++ b/generators/dockertools/templates/java/cli-config.yml.template
@@ -27,13 +27,13 @@ image-name-tools : "bx-dev-java-maven-tools"
 host-path-run : "target"
 
 # The command to build the code and docker image for RUN
-build-cmd-run : "mvn install -Dmaven.repo.local=/project/.m2/repository"
+build-cmd-run : "mvn install -Dmaven.repo.local=/project/.m2/repository -DoutputDirectory=/tmp/liberty"
 
 # The command to execute tests for the code in the tools container
-test-cmd : "mvn install -Dmaven.repo.local=/project/.m2/repository"
+test-cmd : "mvn install -Dmaven.repo.local=/project/.m2/repository -DoutputDirectory=/tmp/liberty"
 
 # The command to build the code and docker image for DEBUG
-build-cmd-debug : "mvn install -Dmaven.repo.local=/project/.m2/repository"
+build-cmd-debug : "mvn install -Dmaven.repo.local=/project/.m2/repository -DoutputDirectory=/tmp/liberty"
 {{/has}}
 {{#has buildType 'gradle'}}
 # The name of image to create from dockerfile-tools


### PR DESCRIPTION
Fix bx dev build failure to build java app in Windows 10 Docker environment. Liberty test server fails to start if the server output directory is in the mapped in volume inside the Windows 10 Docker environment.

Signed-off-by: Patrick Tiu <tiu@ca.ibm.com>