### PR TITLE
fix: escape swift command

### DIFF
--- a/generators/deployment/index.js
+++ b/generators/deployment/index.js
@@ -111,7 +111,7 @@ module.exports = class extends Generator {
 
 	_configureSwift() {
 		this.manifestConfig.buildpack = 'swift_buildpack';
-		this.manifestConfig.command = this.bluemix.name ? (`${this.bluemix.name}`) : undefined;
+		this.manifestConfig.command = this.bluemix.name ? ("\"\'" + `${this.bluemix.name}` + "\'\"") : undefined;
 		this.manifestConfig.memory = this.manifestConfig.memory || '128M';
 		this.pipelineConfig.swift = true;
 		this.cfIgnoreContent = ['.build/*', '.build-ubuntu/*', 'Packages/*'];


### PR DESCRIPTION
Pull request to escape the manifest command so that special characters can be allowed in swift projects.