### PR TITLE
Add Jenkinsfile for Swift

### DIFF
--- a/generators/kubernetes/index.js
+++ b/generators/kubernetes/index.js
@@ -157,6 +157,15 @@ module.exports = class extends Generator {
 				process : true
 			}
 		}
+		
+		// Tested this works OK with Microservice Builder/Microclimate as well
+		if (this.opts.language === 'swift') {
+			this.fileLocations.jenkinsfile = {
+				source : 'swift/Jenkinsfile',
+				target : 'Jenkinsfile',
+				process : true
+			}
+		}
 		else if (this.opts.language === 'java' || this.opts.language === 'spring') {
 			this.fileLocations.deployment.source = 'java/deployment.yaml';
 			this.fileLocations.basedeployment.source = 'java/basedeployment.yaml';

--- a/generators/kubernetes/templates/swift/Jenkinsfile
+++ b/generators/kubernetes/templates/swift/Jenkinsfile
@@ -1,0 +1,6 @@
+#!groovy
+
+@Library('MicroserviceBuilder') _
+microserviceBuilderPipeline {
+  image = '{{#toLowerCase applicationName}}{{/toLowerCase}}'
+}


### PR DESCRIPTION
Note that for this to work right now it's going to rely on [this](https://github.com/WASdev/microservicebuilder.lib/pull/69) PR.

Works by simply providing the Jenkinsfile if you're a Swift project in exactly the same way we do it for Node. In a Swift specific folder incase we want to add any overrides.