### PR TITLE
password no longer required for sudo in tools container

### DIFF
--- a/generators/dockertools/templates/swift/Dockerfile-tools
+++ b/generators/dockertools/templates/swift/Dockerfile-tools
@@ -28,5 +28,11 @@ RUN chmod -R 555 /swift-utils
 # Create user if not root
 RUN if [ "$bx_dev_user" != root ]; then useradd -ms /bin/bash -u $bx_dev_userid $bx_dev_user; fi
 
+# Make password not required for sudo.
+# This is necessary to run 'tools-utils.sh debug' script when executed from an interactive shell.
+# This will not affect the deploy container.
+RUN echo "$bx_dev_user ALL=NOPASSWD: ALL" > /etc/sudoers.d/user && \
+    chmod 0440 /etc/sudoers.d/user
+
 # Bundle application source & binaries
 COPY . /swift-project

--- a/generators/dockertools/templates/swift/Dockerfile-tools
+++ b/generators/dockertools/templates/swift/Dockerfile-tools
@@ -32,7 +32,7 @@ RUN if [ "$bx_dev_user" != root ]; then useradd -ms /bin/bash -u $bx_dev_userid 
 # This is necessary to run 'tools-utils.sh debug' script when executed from an interactive shell.
 # This will not affect the deploy container.
 RUN echo "$bx_dev_user ALL=NOPASSWD: ALL" > /etc/sudoers.d/user && \
-    chmod 0440 /etc/sudoers.d/user
+    chmod 0440 /etc/sudoers.d/user 
 
 # Bundle application source & binaries
 COPY . /swift-project


### PR DESCRIPTION
Previously, if you tried to run the `tools-utils.sh debug` script from inside a shell in the docker container, it would prompt for sudo password, which the end user will not know b/c we don't set it in the tools container.    This change allows the debug script to execute the privileged `echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope` command at any time in the container's lifecycle (not just as entry point/start command) without a disruptive prompt, and does not alter the security or features of the deploy container.