### PR TITLE
[267] Remove deprecated MAINTAINER from Dockerfile templates

### DIFF
--- a/generators/dockertools/templates/java/Dockerfile-tools.template
+++ b/generators/dockertools/templates/java/Dockerfile-tools.template
@@ -1,6 +1,6 @@
 FROM ibmjava:8-sdk
 
-MAINTAINER IBM Java engineering at IBM Cloud
+MAINTAINER IBM Java Engineering at IBM Cloud
 
 RUN apt-get update && apt-get install -y {{#has buildType 'maven'}}maven{{/has}}{{#has buildType 'gradle'}}gradle{{/has}}
 

--- a/generators/dockertools/templates/java/Dockerfile.template
+++ b/generators/dockertools/templates/java/Dockerfile.template
@@ -3,7 +3,7 @@ FROM websphere-liberty:beta
 {{else}}
 FROM websphere-liberty:webProfile7
 {{/libertyBeta}}
-MAINTAINER IBM Java engineering at IBM Cloud
+LABEL maintainer="IBM Java Engineering at IBM Cloud"
 {{#has buildType 'maven'}}
 COPY /target/liberty/wlp/usr/servers/defaultServer /config/
 {{#javametrics}}

--- a/generators/dockertools/templates/spring/Dockerfile-tools.template
+++ b/generators/dockertools/templates/spring/Dockerfile-tools.template
@@ -1,6 +1,6 @@
 FROM ibmjava:8-sdk
 
-MAINTAINER IBM Java engineering at IBM Cloud
+LABEL maintainer="IBM Java Engineering at IBM Cloud"
 
 RUN apt-get update && apt-get install -y {{#has buildType 'maven'}}maven{{/has}}{{#has buildType 'gradle'}}gradle{{/has}}
 

--- a/generators/dockertools/templates/spring/Dockerfile.template
+++ b/generators/dockertools/templates/spring/Dockerfile.template
@@ -1,5 +1,5 @@
 FROM ibmjava:8-sfj
-MAINTAINER IBM Java engineering at IBM Cloud
+LABEL maintainer="IBM Java Engineering at IBM Cloud"
 
 {{#has buildType 'maven'}}
 COPY target/{{artifactId}}-{{version}}.jar /app.jar

--- a/generators/dockertools/templates/swift/Dockerfile
+++ b/generators/dockertools/templates/swift/Dockerfile
@@ -1,5 +1,5 @@
 FROM ibmcom/swift-ubuntu-runtime:4.0
-MAINTAINER IBM Swift Engineering at IBM Cloud
+LABEL maintainer="IBM Swift Engineering at IBM Cloud"
 LABEL Description="Template Dockerfile that extends the ibmcom/swift-ubuntu-runtime image."
 
 # We can replace this port with what the user wants

--- a/generators/dockertools/templates/swift/Dockerfile-tools
+++ b/generators/dockertools/templates/swift/Dockerfile-tools
@@ -1,5 +1,5 @@
 FROM ibmcom/swift-ubuntu:4.0
-MAINTAINER IBM Swift Engineering at IBM Cloud
+LABEL maintainer="IBM Swift Engineering at IBM Cloud"
 LABEL Description="Template Dockerfile that extends the ibmcom/swift-ubuntu image."
 
 # We can replace this port with what the user wants


### PR DESCRIPTION
I changed the MAINTAINER to LABEL maintainer="" as per the deprecation text.  I also changed the E in engineering to an upper case, to match the Swift case (it should be upper case, since it is used as part of  a title.)