### PR TITLE
fix: remove santization on swift executable name

### DIFF
--- a/generators/dockertools/index.js
+++ b/generators/dockertools/index.js
@@ -110,7 +110,7 @@ module.exports = class extends Generator {
 		compilationOptions = compilationOptions.trim();
 
 		const applicationName = Utils.sanitizeAlphaNum(this.bluemix.name);
-		const executableName = applicationName;
+		const executableName = this.bluemix.name;
 
 		const cliConfig = {
 			containerNameRun: `${applicationName.toLowerCase()}-swift-run`,


### PR DESCRIPTION
For swift server projects the executable name is no longer sanitized so that special characters and unicode is allowed. 

This means that if you generate a project with a special character the docker file generated [here](https://github.com/ibm-developer/generator-ibm-cloud-enablement/blob/a38d343fb30021a96cadd5f87e1a999d03ff23c9/generators/dockertools/templates/swift/Dockerfile#L35) does not match the path to your executable since it is sanitized in the file but not in the project.

Changing the path to be the bluemix name will correct this fault and make the dockerfile correct for the swift projects.
