### PR TITLE
fix(deployments): use same containerName and imageNames 

### DIFF
--- a/generators/dockertools/index.js
+++ b/generators/dockertools/index.js
@@ -186,6 +186,8 @@ module.exports = class extends Generator {
 				images: serviceImageNames
 			};
 			this._copyTemplateIfNotExists(FILENAME_DOCKERCOMPOSE, 'swift/docker-compose.yml', dockerComposeConfig);
+			dockerComposeConfig.containerName = `${applicationName.toLowerCase()}-swift-tools`;
+			dockerComposeConfig.image = `${applicationName.toLowerCase()}-swift-tools`;
 			this._copyTemplateIfNotExists(FILENAME_DOCKERCOMPOSE_TOOLS, 'swift/docker-compose-tools.yml', dockerComposeConfig);
 		}
 
@@ -282,6 +284,8 @@ module.exports = class extends Generator {
 				images: serviceImageNames
 			};
 			this._copyTemplateIfNotExists(FILENAME_DOCKERCOMPOSE, 'node/docker-compose.yml', dockerComposeConfig);
+			dockerComposeConfig.containerName = `${applicationName.toLowerCase()}-express-tools`;
+			dockerComposeConfig.image = `${applicationName.toLowerCase()}-express-tools`,
 			this._copyTemplateIfNotExists(FILENAME_DOCKERCOMPOSE_TOOLS, 'node/docker-compose-tools.yml', dockerComposeConfig);
 		}
 
@@ -434,6 +438,8 @@ module.exports = class extends Generator {
 				images: serviceImageNames
 			};
 			this._copyTemplateIfNotExists(FILENAME_DOCKERCOMPOSE, 'python/docker-compose.yml', dockerComposeConfig);
+			dockerComposeConfig.containerName = `${applicationName.toLowerCase()}-flask-tools`;
+			dockerComposeConfig.image = `${applicationName.toLowerCase()}-flask-tools`;
 			this._copyTemplateIfNotExists(FILENAME_DOCKERCOMPOSE_TOOLS, 'python/docker-compose-tools.yml', dockerComposeConfig);
 		}
 
@@ -613,14 +619,16 @@ module.exports = class extends Generator {
 
 		if(this.opts.services.length > 0){
 			const dockerComposeConfig =  {
-				containerName: `${applicationName.toLowerCase()}-flask-run`,
-				image: `${applicationName.toLowerCase()}-flask-run`,
+				containerName: `${applicationName.toLowerCase()}-django-run`,
+				image: `${applicationName.toLowerCase()}-django-run`,
 				ports: [port, debugPort].concat(servicePorts), 
 				envs: serviceEnvs,
 				appPort: port,
 				images: serviceImageNames
 			};
 			this._copyTemplateIfNotExists(FILENAME_DOCKERCOMPOSE, 'python/docker-compose.yml', dockerComposeConfig);
+			dockerComposeConfig.containerName = `${applicationName.toLowerCase()}-django-tools`;
+			dockerComposeConfig.image = `${applicationName.toLowerCase()}-django-tools`;
 			this._copyTemplateIfNotExists(FILENAME_DOCKERCOMPOSE_TOOLS, 'python/docker-compose-tools.yml', dockerComposeConfig);
 		}
 

--- a/test/test-dockertools.js
+++ b/test/test-dockertools.js
@@ -141,6 +141,11 @@ describe('cloud-enablement:dockertools', function () {
 		it('should have the dockerfile-run property set as compose files cli-config.yml', function () {
 			assert.fileContent('cli-config.yml', `dockerfile-run : "docker-compose.yml"`);
 			assert.fileContent('cli-config.yml', `dockerfile-tools : "docker-compose-tools.yml"`);
+			assert.fileContent('docker-compose.yml', `container_name: "${applicationName.toLowerCase()}-express-run"`);
+			assert.fileContent('docker-compose.yml', `image: "${applicationName.toLowerCase()}-express-run"`);
+			assert.fileContent('docker-compose-tools.yml', `container_name: "${applicationName.toLowerCase()}-express-tools"`);
+			assert.fileContent('docker-compose-tools.yml', `image: "${applicationName.toLowerCase()}-express-tools"`);
+
 		});
 		
 		it('create docker-compose.yml and docker-compose-tools.yml for running', function () {
@@ -509,6 +514,13 @@ describe('cloud-enablement:dockertools', function () {
 			assert.file(['docker-compose.yml']);
 		});
 
+		it('should have the correct image name and container name for docker-compose and docker-compose-tools', function() {
+			assert.fileContent('docker-compose.yml', `container_name: "${applicationName.toLowerCase()}-flask-run"`);
+			assert.fileContent('docker-compose.yml', `image: "${applicationName.toLowerCase()}-flask-run"`);
+			assert.fileContent('docker-compose-tools.yml', `container_name: "${applicationName.toLowerCase()}-flask-tools"`);
+			assert.fileContent('docker-compose-tools.yml', `image: "${applicationName.toLowerCase()}-flask-tools"`);
+		});
+
 		
 		it('docker-compose-tools.yml with flask', function () {
 			assert.file(['docker-compose-tools.yml']);
@@ -679,6 +691,10 @@ describe('cloud-enablement:dockertools', function () {
 
 		it('create docker-compose and docker-compose-tools django', function () {
 			assert.file(['docker-compose.yml', 'docker-compose-tools.yml']);
+			assert.fileContent('docker-compose.yml', `container_name: "${applicationName.toLowerCase()}-django-run"`);
+			assert.fileContent('docker-compose.yml', `image: "${applicationName.toLowerCase()}-django-run"`);
+			assert.fileContent('docker-compose-tools.yml', `container_name: "${applicationName.toLowerCase()}-django-tools"`);
+			assert.fileContent('docker-compose-tools.yml', `image: "${applicationName.toLowerCase()}-django-tools"`);
 		})
 
 		it('create CLI-config file', function () {


### PR DESCRIPTION
Docker-compose and Docker-compose-tools was not using the same image names and container names that are in Dockerfile and Dockerfile-tools