### PR TITLE
fix(deployment): remove production installation when running local/dev containers

### DIFF
--- a/generators/dockertools/index.js
+++ b/generators/dockertools/index.js
@@ -261,9 +261,9 @@ module.exports = class extends Generator {
 			dockerFileTools,
 			imageNameRun: `${applicationName.toLowerCase()}-express-run`,
 			imageNameTools: `${applicationName.toLowerCase()}-express-tools`,
-			buildCmdRun: 'npm install --production --unsafe-perm',
+			buildCmdRun: 'npm install' ,
 			testCmd: 'npm run test',
-			buildCmdDebug: 'npm install --unsafe-perm',
+			buildCmdDebug: 'npm install',
 			runCmd: '',
 			stopCmd: "npm stop",
 			chartPath: `chart/${applicationName.toLowerCase()}`


### PR DESCRIPTION
The cli-config file runs either `bmd-run-cmd` or `bmd-debug-cmd` after build is complete. In node, we need the dependencies and not just the production modules to run node starters that use webpack. 