### PR TITLE
feat(deployment): added USER so application is not being run as root

### DIFF
--- a/generators/dockertools/templates/node/Dockerfile
+++ b/generators/dockertools/templates/node/Dockerfile
@@ -23,6 +23,8 @@ ENV PORT <%= port %>
 
 EXPOSE <%= port %>
 
+USER node
+
 CMD ["npm", "start"]
 
 

--- a/generators/dockertools/templates/node/Dockerfile-tools
+++ b/generators/dockertools/templates/node/Dockerfile-tools
@@ -20,14 +20,11 @@ RUN apt-get install bc
 CMD ["/bin/bash"]
 
 
-ARG bx_dev_user=root
+ARG bx_dev_user=node
 ARG bx_dev_userid=1000
 RUN BX_DEV_USER=$bx_dev_user
 RUN BX_DEV_USERID=$bx_dev_userid
-RUN if [ "$bx_dev_user" != root ]; then useradd -ms /bin/bash -u $bx_dev_userid $bx_dev_user; fi
+RUN if [ "$bx_dev_user" != root -a "$bx_dev_user" != node ]; then useradd -ms /bin/bash -u $bx_dev_userid $bx_dev_user; fi
 
-
-
-
-
-
+RUN chown $bx_dev_user /app 
+USER $bx_dev_user


### PR DESCRIPTION
Dockerfile will now use the user 'node' instead of root.
Dockerfile-tools has a default user as 'node' but can still be changed with command line argument 'bx_dev_user'