### PR TITLE
fix: change kube_deploy to grab first port

### DIFF
--- a/generators/deployment/templates/kube_deploy.sh
+++ b/generators/deployment/templates/kube_deploy.sh
@@ -120,5 +120,5 @@ helm history ${RELEASE_NAME}
 
 echo "=========================================================="
 IP_ADDR=$(bx cs workers ${PIPELINE_KUBERNETES_CLUSTER_NAME} | grep normal | head -n 1 | awk '{ print $2 }')
-PORT=$(kubectl get services --namespace ${CLUSTER_NAMESPACE} | grep ${RELEASE_NAME} | sed 's/.*:\([0-9]*\).*/\1/g')
+PORT=$(kubectl get services --namespace ${CLUSTER_NAMESPACE} | grep ${RELEASE_NAME} | sed 's/[^:]*:\([0-9]*\).*/\1/g')
 echo -e "View the application at: http://${IP_ADDR}:${PORT}"


### PR DESCRIPTION
https://github.ibm.com/arf/planning-languages/issues/300

Java starters deployed on kubes should actually be deploying correctly. The problem is the url that the logs print out is incorrect. It's grabbing the https port instead of the http port.

This PR fixes that--changing the `sed` regex from greedy to eager (grabbing the first port instead of second). Testing needs to be done for any starters that provide multiple ports.

