### PR TITLE
fix: typo wrong kind of quotes

### DIFF
--- a/generators/dockertools/templates/go/Dockerfile-tools
+++ b/generators/dockertools/templates/go/Dockerfile-tools
@@ -28,4 +28,4 @@ ARG bx_dev_user=root
 ARG bx_dev_userid=1000
 RUN BX_DEV_USER=$bx_dev_user
 RUN BX_DEV_USERID=$bx_dev_userid
-RUN if [ “$bx_dev_user” != root ]; then adduser -D -s /bin/bash -u $bx_dev_userid $bx_dev_user; fi
+RUN if [ "$bx_dev_user" != root ]; then adduser -D -s /bin/bash -u $bx_dev_userid $bx_dev_user; fi


### PR DESCRIPTION
The $bx_dev_user variable was not translating due to having the wrong type of quotes around it in the last line of this file.