### PR TITLE
fix: move node base image up to 8-stretch

### DIFF
--- a/generators/dockertools/templates/node/Dockerfile
+++ b/generators/dockertools/templates/node/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8
+FROM node:8-stretch
 
 # Change working directory
 WORKDIR "/app"

--- a/generators/dockertools/templates/node/Dockerfile-tools
+++ b/generators/dockertools/templates/node/Dockerfile-tools
@@ -1,4 +1,4 @@
-FROM node:8
+FROM node:8-stretch
 
 
 ENV PORT {{port}}


### PR DESCRIPTION
The template for the node generator has `node:8 `as base image in the generated dockerfiles. The `node:8`
image is based on the Debian "jessie" release, which is no longer supported for ppc64le and s390x architectures. So the apt-get update line in the generated dockerfiles now fails on those platforms, see
nodejs/docker-node#855. 

Fix is to update the base image to `node:8-stretch`, which uses the current stable debian release ("stretch", see https://www.debian.org/releases/)

Fix for https://github.com/ibm-developer/generator-ibm-cloud-enablement/issues/395