### PR TITLE
fix: Update the dockerfile apm config so it works correctly

### DIFF
--- a/generators/dockertools/templates/java/Dockerfile.template
+++ b/generators/dockertools/templates/java/Dockerfile.template
@@ -16,7 +16,9 @@ COPY /build/wlp/usr/servers/defaultServer /config/
 {{/has}}
 # Install required features if not present, install APM Data Collector
 RUN installUtility install --acceptLicense defaultServer && installUtility install --acceptLicense apmDataCollector-7.4
-RUN /opt/ibm/wlp/usr/extension/liberty_dc/bin/config_liberty_dc.sh -silent /opt/ibm/wlp/usr/extension/liberty_dc/bin/silent_config_liberty_dc.txt
+ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/lib:/opt/ibm/wlp/usr/extension/liberty_dc/toolkit/lib/lx8266 \
+ JVM_ARGS="$JVM_ARGS -agentlib:am_ibm_16=defaultServer -Xbootclasspath/p:/opt/ibm/wlp/usr/extension/liberty_dc/toolkit/lib/bcm-bootstrap.jar -Xverbosegclog:/logs/gc.log,1,10000 -verbosegc -Djava.security.policy=/opt/ibm/wlp/usr/extension/liberty_dc/itcamdc/etc/datacollector.policy -Dliberty.home=/opt/ibm/wlp"
+
 # Upgrade to production license if URL to JAR provided
 ARG LICENSE_JAR_URL
 RUN \ 

--- a/test/test-dockertools.js
+++ b/test/test-dockertools.js
@@ -306,8 +306,11 @@ describe('cloud-enablement:dockertools', function () {
 					it('Dockerfile contains apmDataCollector-7.4', function () {
 						assert.fileContent('Dockerfile', 'apmDataCollector-7.4');
 					});
-					it('Dockerfile contains config_liberty_dc.sh', function () {
-						assert.fileContent('Dockerfile', 'config_liberty_dc.sh');
+					it('Dockerfile contains LD_LIBRARY_PATH', function () {
+						assert.fileContent('Dockerfile', 'LD_LIBRARY_PATH');
+					});
+					it('Dockerfile contains JVM_ARGS', function () {
+						assert.fileContent('Dockerfile', 'JVM_ARGS');
 					});
 					it('Dockerfile-tools contains wlp path', function () {
 						assert.fileContent('Dockerfile-tools', 'wlp/bin');


### PR DESCRIPTION
Making a few changes so the APM config works correctly. There were a few issues:

1. the changes to server.env were not valid and likely never worked as expected. It relied on doing variable expansion which isn't supported in server.env
1. it didn't work with the Liberty container in non-root mode which is best practice
1. I'm suspicious of the -Xmx setting the heap to 728Mb. If the docker container has a smaller memory limit this will break.

To make this work I've put the server.env changes in as a docker env var and for the jvm args I've specified them using JVM_ARGS.

I haven't moved the -Xmx setting. I think it is probably better to set the heap usage to use a % of available memory. I think there is a way to do this, but I think this might make sense to put in the base image.