### PR TITLE
fix: Remove apm tools from Liberty docker image

### DIFF
--- a/generators/dockertools/templates/java/Dockerfile.template
+++ b/generators/dockertools/templates/java/Dockerfile.template
@@ -19,10 +19,6 @@ COPY /build/wlp/usr/servers/defaultServer /config/
 USER root
 RUN chmod g+w /config/apps
 USER 1001
-# Install required features if not present, install APM Data Collector
-RUN installUtility install --acceptLicense defaultServer && installUtility install --acceptLicense apmDataCollector-7.4
-ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/lib:/opt/ibm/wlp/usr/extension/liberty_dc/toolkit/lib/lx8266 \
- JVM_ARGS="$JVM_ARGS -agentlib:am_ibm_16=defaultServer -Xbootclasspath/p:/opt/ibm/wlp/usr/extension/liberty_dc/toolkit/lib/bcm-bootstrap.jar -Xverbosegclog:/logs/gc.log,1,10000 -verbosegc -Djava.security.policy=/opt/ibm/wlp/usr/extension/liberty_dc/itcamdc/etc/datacollector.policy -Dliberty.home=/opt/ibm/wlp"
 
 # Upgrade to production license if URL to JAR provided
 ARG LICENSE_JAR_URL

--- a/test/test-dockertools.js
+++ b/test/test-dockertools.js
@@ -297,20 +297,8 @@ describe('cloud-enablement:dockertools', function () {
 						assert.fileContent('.dockerignore', 'workarea');
 						assert.fileContent('.dockerignore', 'logs');
 					});
-					it('Dockerfile contains installUtility', function () {
-						assert.fileContent('Dockerfile', 'installUtility');
-					});
 					it('Dockerfile contains LICENSE_JAR_URL', function () {
 						assert.fileContent('Dockerfile', 'LICENSE_JAR_URL');
-					});
-					it('Dockerfile contains apmDataCollector-7.4', function () {
-						assert.fileContent('Dockerfile', 'apmDataCollector-7.4');
-					});
-					it('Dockerfile contains LD_LIBRARY_PATH', function () {
-						assert.fileContent('Dockerfile', 'LD_LIBRARY_PATH');
-					});
-					it('Dockerfile contains JVM_ARGS', function () {
-						assert.fileContent('Dockerfile', 'JVM_ARGS');
 					});
 					it('Dockerfile-tools contains wlp path', function () {
 						assert.fileContent('Dockerfile-tools', 'wlp/bin');


### PR DESCRIPTION
Duplicate of PR #414 (@NottyCode's pr) because devops not updated to handle forks yet.