### PR TITLE
fix: Restore step to install missing features for server.

### DIFF
--- a/generators/dockertools/templates/java/Dockerfile.template
+++ b/generators/dockertools/templates/java/Dockerfile.template
@@ -19,6 +19,8 @@ COPY /build/wlp/usr/servers/defaultServer /config/
 USER root
 RUN chmod g+w /config/apps
 USER 1001
+# install any missing features required by server config
+RUN installUtility install --acceptLicense defaultServer
 
 # Upgrade to production license if URL to JAR provided
 ARG LICENSE_JAR_URL


### PR DESCRIPTION
A prior change to remove APM also ended up removing the step that
installs any features in server config that are not in the base image

See bug #429 