### PR TITLE
fix: Restore test to validate installUtility present

### DIFF
--- a/test/test-dockertools.js
+++ b/test/test-dockertools.js
@@ -295,6 +295,9 @@ describe('cloud-enablement:dockertools', function () {
 						assert.fileContent('.dockerignore', 'workarea');
 						assert.fileContent('.dockerignore', 'logs');
 					});
+					it('Dockerfile contains installUtility', function () {
+						assert.fileContent('Dockerfile', 'installUtility');
+					});
 					it('Dockerfile contains LICENSE_JAR_URL', function () {
 						assert.fileContent('Dockerfile', 'LICENSE_JAR_URL');
 					});


### PR DESCRIPTION
A prior change to remove APM ( https://github.com/ibm-developer/generator-ibm-cloud-enablement/pull/414/files ) removed the usage and tests for installUtility.

The installUtility Dockerfile change was needed to install missing features for server  and was fixed here  https://github.com/ibm-developer/generator-ibm-cloud-enablement/commit/48233467cf7daf192a3807b4bf82b13c6e4e9ab1

This commit adds the test back to what it was before.