### PR TITLE
fix: upgrade Swift version to 4.2.1

### DIFF
--- a/generators/dockertools/templates/swift/Dockerfile
+++ b/generators/dockertools/templates/swift/Dockerfile
@@ -1,4 +1,4 @@
-FROM ibmcom/swift-ubuntu-runtime:4.2
+FROM ibmcom/swift-ubuntu-runtime:4.2.1
 LABEL maintainer="IBM Swift Engineering at IBM Cloud"
 LABEL Description="Template Dockerfile that extends the ibmcom/swift-ubuntu-runtime image."
 

--- a/generators/dockertools/templates/swift/Dockerfile-tools
+++ b/generators/dockertools/templates/swift/Dockerfile-tools
@@ -1,4 +1,4 @@
-FROM ibmcom/swift-ubuntu:4.2
+FROM ibmcom/swift-ubuntu:4.2.1
 LABEL maintainer="IBM Swift Engineering at IBM Cloud"
 LABEL Description="Template Dockerfile that extends the ibmcom/swift-ubuntu image."
 


### PR DESCRIPTION
This upgrades the version of Swift used in the base IBM Docker images from `4.2` to `4.2.1`.