### PR TITLE
fix: Fix ic dev build for Node projects

### DIFF
--- a/generators/dockertools/index.js
+++ b/generators/dockertools/index.js
@@ -204,8 +204,8 @@ module.exports = class extends Generator {
 
 	_generateNodeJS() {
 		const applicationName = Utils.sanitizeAlphaNum(this.bluemix.name);
-		const dockerFileRun = 'docker-compose.yml';
-		const dockerFileTools = 'docker-compose-tools.yml';
+		const dockerFileRun = this.opts.services.length > 0 ? 'docker-compose.yml' : 'Dockerfile';
+		const dockerFileTools = this.opts.services.length > 0 ? 'docker-compose-tools.yml' : 'Dockerfile-tools';
 		const port = this.opts.port ? this.opts.port : '3000';
 		const debugPort = '9229';
 

--- a/test/test-dockertools.js
+++ b/test/test-dockertools.js
@@ -165,8 +165,8 @@ describe('cloud-enablement:dockertools', function () {
 		});
 
 		it('should have Dockerfile and Dockerfile-tools as the docker run commands', function() {
-			assert.fileContent('cli-config.yml', 'dockerfile-run : "docker-compose.yml"');
-			assert.fileContent('cli-config.yml', 'dockerfile-tools : "docker-compose-tools.yml"');
+			assert.fileContent('cli-config.yml', 'dockerfile-run : "Dockerfile"');
+			assert.fileContent('cli-config.yml', 'dockerfile-tools : "Dockerfile-tools"');
 		});
 
 		it('should have the correct EXPOSE instruction for Dockerfile and Dockerfile-tools', function() {


### PR DESCRIPTION
Change cli-config.yml back to Dockerfiles, instead of compose yamls, until CLI can be changed to do the correct docker-compose command.