### PR TITLE
fix: swift 4.2.2 docker image support

### DIFF
--- a/generators/dockertools/templates/swift/Dockerfile
+++ b/generators/dockertools/templates/swift/Dockerfile
@@ -1,4 +1,4 @@
-FROM ibmcom/swift-ubuntu-runtime:4.2.1
+FROM ibmcom/swift-ubuntu-runtime:4.2.2
 LABEL maintainer="IBM Swift Engineering at IBM Cloud"
 LABEL Description="Template Dockerfile that extends the ibmcom/swift-ubuntu-runtime image."
 

--- a/generators/dockertools/templates/swift/Dockerfile-tools
+++ b/generators/dockertools/templates/swift/Dockerfile-tools
@@ -1,4 +1,4 @@
-FROM ibmcom/swift-ubuntu:4.2.1
+FROM ibmcom/swift-ubuntu:4.2.2
 LABEL maintainer="IBM Swift Engineering at IBM Cloud"
 LABEL Description="Template Dockerfile that extends the ibmcom/swift-ubuntu image."
 


### PR DESCRIPTION
Upgrade to use the new Swift 4.2.2 docker images.