### PR TITLE
fix: add cluster role binding #468

### DIFF
--- a/generators/deployment/templates/kube_deploy.sh
+++ b/generators/deployment/templates/kube_deploy.sh
@@ -19,6 +19,14 @@ else
   echo -e "Namespace ${CLUSTER_NAMESPACE} created."
 fi
 
+echo "Configuring cluster role binding"
+if kubectl get clusterrolebinding kube-system:default; then
+  echo -e "Cluster role binding found."
+else
+  kubectl create clusterrolebinding kube-system:default --clusterrole=cluster-admin --serviceaccount=kube-system:default
+  echo -e "Cluster role binding created."
+fi
+
 echo "Configuring Tiller (Helm's server component)"
 helm init --upgrade
 kubectl rollout status -w deployment/tiller-deploy --namespace=kube-system


### PR DESCRIPTION
By adding this code to the deploy script, we ensure that a cluster role binding is created before invoking `helm` commands.

See https://console.bluemix.net/docs/containers/cs_versions.html#cs_v112.

Closes #468 .