### PR TITLE
fix: health curl flag change

### DIFF
--- a/generators/deployment/templates/pipeline_master.yml
+++ b/generators/deployment/templates/pipeline_master.yml
@@ -248,7 +248,7 @@ stages:
       echo "RELEASE_NAME: $RELEASE_NAME"
 
       PORT=$(kubectl get services --namespace ${CLUSTER_NAMESPACE} | grep ${RELEASE_NAME} | sed 's/[^:]*:\([0-9]*\).*/\1/g')
-      if [ "$(curl -Is http://$IP_ADDR:$PORT/health --connect-timeout 3 --max-time 5 --retry 2 --retry-max-time 30 | head -n 1 | grep 200)" != "" ]; then
+      if [ "$(curl -is http://$IP_ADDR:$PORT/health --connect-timeout 3 --max-time 5 --retry 2 --retry-max-time 30 | head -n 1 | grep 200)" != "" ]; then
         echo "Successfully reached health endpoint"
         echo "====================================================================="
       else
@@ -285,7 +285,7 @@ stages:
     script: |-
       #!/bin/sh
       apk add --no-cache curl
-      if [ "$(curl -Is http://{{manifest.host}}.{{manifest.domain}}/health  --connect-timeout 3 --max-time 5 --retry 3 --retry-max-time 30 | head -n 1 | grep 200)" != "" ]; then
+      if [ "$(curl -is http://{{manifest.host}}.{{manifest.domain}}/health  --connect-timeout 3 --max-time 5 --retry 3 --retry-max-time 30 | head -n 1 | grep 200)" != "" ]; then
         echo "Successfully reached health endpoint"
         echo "====================================================================="
       else

--- a/test/samples/pipeline-cf-java.yml
+++ b/test/samples/pipeline-cf-java.yml
@@ -79,7 +79,7 @@ stages:
     script: |-
       #!/bin/sh
       apk add --no-cache curl
-      if [ "$(curl -Is http://myapp.ng.bluemix.net/health  --connect-timeout 3 --max-time 5 --retry 3 --retry-max-time 30 | head -n 1 | grep 200)" != "" ]; then
+      if [ "$(curl -is http://myapp.ng.bluemix.net/health  --connect-timeout 3 --max-time 5 --retry 3 --retry-max-time 30 | head -n 1 | grep 200)" != "" ]; then
         echo "Successfully reached health endpoint"
         echo "====================================================================="
       else

--- a/test/samples/pipeline-cf-spring.yml
+++ b/test/samples/pipeline-cf-spring.yml
@@ -79,7 +79,7 @@ stages:
     script: |-
       #!/bin/sh
       apk add --no-cache curl
-      if [ "$(curl -Is http://myapp.ng.bluemix.net/health  --connect-timeout 3 --max-time 5 --retry 3 --retry-max-time 30 | head -n 1 | grep 200)" != "" ]; then
+      if [ "$(curl -is http://myapp.ng.bluemix.net/health  --connect-timeout 3 --max-time 5 --retry 3 --retry-max-time 30 | head -n 1 | grep 200)" != "" ]; then
         echo "Successfully reached health endpoint"
         echo "====================================================================="
       else

--- a/test/samples/pipeline-cf-swift.yml
+++ b/test/samples/pipeline-cf-swift.yml
@@ -76,7 +76,7 @@ stages:
     script: |-
       #!/bin/sh
       apk add --no-cache curl
-      if [ "$(curl -Is http://myapp.ng.bluemix.net/health  --connect-timeout 3 --max-time 5 --retry 3 --retry-max-time 30 | head -n 1 | grep 200)" != "" ]; then
+      if [ "$(curl -is http://myapp.ng.bluemix.net/health  --connect-timeout 3 --max-time 5 --retry 3 --retry-max-time 30 | head -n 1 | grep 200)" != "" ]; then
         echo "Successfully reached health endpoint"
         echo "====================================================================="
       else

--- a/test/samples/pipeline-cf.yml
+++ b/test/samples/pipeline-cf.yml
@@ -77,7 +77,7 @@ stages:
     script: |-
       #!/bin/sh
       apk add --no-cache curl
-      if [ "$(curl -Is http://myapp.ng.bluemix.net/health  --connect-timeout 3 --max-time 5 --retry 3 --retry-max-time 30 | head -n 1 | grep 200)" != "" ]; then
+      if [ "$(curl -is http://myapp.ng.bluemix.net/health  --connect-timeout 3 --max-time 5 --retry 3 --retry-max-time 30 | head -n 1 | grep 200)" != "" ]; then
         echo "Successfully reached health endpoint"
         echo "====================================================================="
       else

--- a/test/samples/pipeline-kube-java.yml
+++ b/test/samples/pipeline-kube-java.yml
@@ -158,7 +158,7 @@ stages:
       echo "RELEASE_NAME: $RELEASE_NAME"
 
       PORT=$(kubectl get services --namespace ${CLUSTER_NAMESPACE} | grep ${RELEASE_NAME} | sed 's/[^:]*:\([0-9]*\).*/\1/g')
-      if [ "$(curl -Is http://$IP_ADDR:$PORT/health --connect-timeout 3 --max-time 5 --retry 2 --retry-max-time 30 | head -n 1 | grep 200)" != "" ]; then
+      if [ "$(curl -is http://$IP_ADDR:$PORT/health --connect-timeout 3 --max-time 5 --retry 2 --retry-max-time 30 | head -n 1 | grep 200)" != "" ]; then
         echo "Successfully reached health endpoint"
         echo "====================================================================="
       else

--- a/test/samples/pipeline-kube-swift.yml
+++ b/test/samples/pipeline-kube-swift.yml
@@ -149,7 +149,7 @@ stages:
       echo "RELEASE_NAME: $RELEASE_NAME"
 
       PORT=$(kubectl get services --namespace ${CLUSTER_NAMESPACE} | grep ${RELEASE_NAME} | sed 's/[^:]*:\([0-9]*\).*/\1/g')
-      if [ "$(curl -Is http://$IP_ADDR:$PORT/health --connect-timeout 3 --max-time 5 --retry 2 --retry-max-time 30 | head -n 1 | grep 200)" != "" ]; then
+      if [ "$(curl -is http://$IP_ADDR:$PORT/health --connect-timeout 3 --max-time 5 --retry 2 --retry-max-time 30 | head -n 1 | grep 200)" != "" ]; then
         echo "Successfully reached health endpoint"
         echo "====================================================================="
       else

--- a/test/samples/pipeline-kube.yml
+++ b/test/samples/pipeline-kube.yml
@@ -144,7 +144,7 @@ stages:
       echo "RELEASE_NAME: $RELEASE_NAME"
 
       PORT=$(kubectl get services --namespace ${CLUSTER_NAMESPACE} | grep ${RELEASE_NAME} | sed 's/[^:]*:\([0-9]*\).*/\1/g')
-      if [ "$(curl -Is http://$IP_ADDR:$PORT/health --connect-timeout 3 --max-time 5 --retry 2 --retry-max-time 30 | head -n 1 | grep 200)" != "" ]; then
+      if [ "$(curl -is http://$IP_ADDR:$PORT/health --connect-timeout 3 --max-time 5 --retry 2 --retry-max-time 30 | head -n 1 | grep 200)" != "" ]; then
         echo "Successfully reached health endpoint"
         echo "====================================================================="
       else


### PR DESCRIPTION
This change changes the [curl command](http://www.mit.edu/afs.new/sipb/user/ssen/src/curl-7.11.1/docs/curl.html) used by the Health Stage for Kubernetes and CF deployments.  The VSI check continues to use `-sL`.

Previously, the `-I` flags we used which sent a HEAD request to the application.  This was a problem for Swift applications, where the Health Stage failed with a 404 because Kitura does not currently process HEAD requests as GET requests, unlike other routers.  [This may change soon.](https://github.com/IBM-Swift/Kitura/issues/1414)

The solution in the meantime is to use the `-i` flag, which gets that header information in addition to the content from the GET request.  There is no impact of this change as we continue to grep the output of the curl command for the response code, so the additional content returned is irrelevant.