### PR TITLE
vsi java fix

### DIFF
--- a/generators/deployment/templates/vsi_pipeline_master.yml
+++ b/generators/deployment/templates/vsi_pipeline_master.yml
@@ -180,11 +180,11 @@ stages:
       apk add --no-cache openssh rsync
       VSI_HOST=$(cat hostip.txt)
       ssh -o StrictHostKeyChecking=no -i ssh_private_key root@$VSI_HOST "apt-get update; apt-get install rsync; mkdir -p app"
-      rsync -arv -e "ssh -i ssh_private_key" {{name}}-0.0_1-1_all.deb root@$VSI_HOST:app
 
+    {{#has deployment.language 'JAVA'}}
+      rsync -arv -e "ssh -i ssh_private_key" {{name}}-0.0_1-1_all.deb root@$VSI_HOST:app
       echo "scripts/install.sh initial"
       cat scripts/install.sh
-
       # https://unix.stackexchange.com/questions/508724/failed-to-fetch-jessie-backports-repository
       echo "apt-get update" > scripts/install.sh
       echo "apt-get install -f" >> scripts/install.sh
@@ -192,11 +192,26 @@ stages:
       echo 'echo "Acquire::Check-Valid-Until \"false\";" > /etc/apt/apt.conf.d/100disablechecks' >> scripts/install.sh
       echo 'apt-get -o Acquire::Check-Valid-Until=false update' >> scripts/install.sh
       echo 'apt-get install -y -t jessie-backports openjdk-8-jre' >> scripts/install.sh
-
       echo "install.sh updated"
       cat scripts/install.sh
-
       rsync -arv -e "ssh -i ssh_private_key" scripts/install.sh root@$VSI_HOST:app
+    {{/has}}
+
+    {{#has deployment.language 'SPRING'}}
+      rsync -arv -e "ssh -i ssh_private_key" {{name}}-0.0_1-1_all.deb root@$VSI_HOST:app
+      echo "scripts/install.sh initial"
+      cat scripts/install.sh
+      # https://unix.stackexchange.com/questions/508724/failed-to-fetch-jessie-backports-repository
+      echo "apt-get update" > scripts/install.sh
+      echo "apt-get install -f" >> scripts/install.sh
+      echo 'echo "deb http://archive.debian.org/debian jessie-backports main" >> /etc/apt/sources.list' >> scripts/install.sh
+      echo 'echo "Acquire::Check-Valid-Until \"false\";" > /etc/apt/apt.conf.d/100disablechecks' >> scripts/install.sh
+      echo 'apt-get -o Acquire::Check-Valid-Until=false update' >> scripts/install.sh
+      echo 'apt-get install -y -t jessie-backports openjdk-8-jre' >> scripts/install.sh
+      echo "install.sh updated"
+      cat scripts/install.sh
+      rsync -arv -e "ssh -i ssh_private_key" scripts/install.sh root@$VSI_HOST:app
+    {{/has}}
     docker_image: alpine
   - name: Install
     type: builder
@@ -206,7 +221,28 @@ stages:
       #!/bin/bash
       set -eo pipefail
       VSI_HOST=$(cat hostip.txt)
+
+    {{#has deployment.language 'JAVA'}}
       ssh -o StrictHostKeyChecking=no -i ssh_private_key root@$VSI_HOST "rm -rf /usr/src/{{name}}; cd app; dpkg -i {{name}}-0.0_1-1_all.deb; source install.sh"
+    {{/has}}
+    {{#has deployment.language 'SPRING'}}
+      ssh -o StrictHostKeyChecking=no -i ssh_private_key root@$VSI_HOST "rm -rf /usr/src/{{name}}; cd app; dpkg -i {{name}}-0.0_1-1_all.deb; source install.sh"
+    {{/has}}
+    {{#has deployment.language 'NODE'}}
+      ssh -o StrictHostKeyChecking=no -i ssh_private_key root@$VSI_HOST "rm -rf /usr/src/{{name}}; cd app; dpkg -i {{name}}-0.0_1-1_all.deb; cd /usr/src/{{name}}; source install.sh"
+    {{/has}}
+    {{#has deployment.language 'PYTHON'}}
+      ssh -o StrictHostKeyChecking=no -i ssh_private_key root@$VSI_HOST "rm -rf /usr/src/{{name}}; cd app; dpkg -i {{name}}-0.0_1-1_all.deb; cd /usr/src/{{name}}; source install.sh"
+    {{/has}}
+    {{#has deployment.language 'DJANGO'}}
+      ssh -o StrictHostKeyChecking=no -i ssh_private_key root@$VSI_HOST "rm -rf /usr/src/{{name}}; cd app; dpkg -i {{name}}-0.0_1-1_all.deb; cd /usr/src/{{name}}; source install.sh"
+    {{/has}}
+    {{#has deployment.language 'SWIFT'}}
+      ssh -o StrictHostKeyChecking=no -i ssh_private_key root@$VSI_HOST "rm -rf /usr/src/{{name}}; cd app; dpkg -i {{name}}-0.0_1-1_all.deb; cd /usr/src/{{name}}; source install.sh"
+    {{/has}}
+    {{#has deployment.language 'GO'}}
+      ssh -o StrictHostKeyChecking=no -i ssh_private_key root@$VSI_HOST "rm -rf /usr/src/{{name}}; cd app; dpkg -i {{name}}-0.0_1-1_all.deb; cd /usr/src/{{name}}; source install.sh"
+    {{/has}}
   - name: Start
     type: builder
     artifact_dir: ''

--- a/generators/deployment/templates/vsi_pipeline_master.yml
+++ b/generators/deployment/templates/vsi_pipeline_master.yml
@@ -181,6 +181,22 @@ stages:
       VSI_HOST=$(cat hostip.txt)
       ssh -o StrictHostKeyChecking=no -i ssh_private_key root@$VSI_HOST "apt-get update; apt-get install rsync; mkdir -p app"
       rsync -arv -e "ssh -i ssh_private_key" {{name}}-0.0_1-1_all.deb root@$VSI_HOST:app
+
+      echo "scripts/install.sh initial"
+      cat scripts/install.sh
+
+      # https://unix.stackexchange.com/questions/508724/failed-to-fetch-jessie-backports-repository
+      echo "apt-get update" > scripts/install.sh
+      echo "apt-get install -f" >> scripts/install.sh
+      echo 'echo "deb http://archive.debian.org/debian jessie-backports main" >> /etc/apt/sources.list' >> scripts/install.sh
+      echo 'echo "Acquire::Check-Valid-Until \"false\";" > /etc/apt/apt.conf.d/100disablechecks' >> scripts/install.sh
+      echo 'apt-get -o Acquire::Check-Valid-Until=false update' >> scripts/install.sh
+      echo 'apt-get install -y -t jessie-backports openjdk-8-jre' >> scripts/install.sh
+
+      echo "install.sh updated"
+      cat scripts/install.sh
+
+      rsync -arv -e "ssh -i ssh_private_key" scripts/install.sh root@$VSI_HOST:app
     docker_image: alpine
   - name: Install
     type: builder
@@ -190,7 +206,7 @@ stages:
       #!/bin/bash
       set -eo pipefail
       VSI_HOST=$(cat hostip.txt)
-      ssh -o StrictHostKeyChecking=no -i ssh_private_key root@$VSI_HOST "rm -rf /usr/src/{{name}}; cd app; dpkg -i {{name}}-0.0_1-1_all.deb; cd /usr/src/{{name}}; source install.sh"
+      ssh -o StrictHostKeyChecking=no -i ssh_private_key root@$VSI_HOST "rm -rf /usr/src/{{name}}; cd app; dpkg -i {{name}}-0.0_1-1_all.deb; source install.sh"
   - name: Start
     type: builder
     artifact_dir: ''
@@ -237,6 +253,10 @@ stages:
       {{#has deployment.language 'GO'}}
       PORT='8080'
       {{/has}}
+
+      # sleep for 10 seconds to allow enough time for the server to start
+      sleep 10
+
       if [ $(curl -sL -w "%{http_code}\\n" "http://${VSI_HOST}:${PORT}/{{#if healthEndpoint}}{{healthEndpoint}}{{else}}health{{/if}}" -o /dev/null --connect-timeout 3 --max-time 5 --retry 3 --retry-max-time 30) == "200" ]; then
         echo "Successfully reached health endpoint: http://${VSI_HOST}:${PORT}/{{#if healthEndpoint}}{{healthEndpoint}}{{else}}health{{/if}}"
         echo "====================================================================="


### PR DESCRIPTION
Fix to make vsi deployment for java apps operational again.  This is a patch.  The real fix will be to update the version of debian/dependencies so we don't have to patch and use archives.  

Fix based on thread here: https://unix.stackexchange.com/questions/508724/failed-to-fetch-jessie-backports-repository