### PR TITLE
fix: patched vsi deployment for java projects (outdated os/dependency)

### DIFF
--- a/generators/deployment/templates/vsi_pipeline_master.yml
+++ b/generators/deployment/templates/vsi_pipeline_master.yml
@@ -180,7 +180,38 @@ stages:
       apk add --no-cache openssh rsync
       VSI_HOST=$(cat hostip.txt)
       ssh -o StrictHostKeyChecking=no -i ssh_private_key root@$VSI_HOST "apt-get update; apt-get install rsync; mkdir -p app"
+
+    {{#has deployment.language 'JAVA'}}
       rsync -arv -e "ssh -i ssh_private_key" {{name}}-0.0_1-1_all.deb root@$VSI_HOST:app
+      echo "scripts/install.sh initial"
+      cat scripts/install.sh
+      # https://unix.stackexchange.com/questions/508724/failed-to-fetch-jessie-backports-repository
+      echo "apt-get update" > scripts/install.sh
+      echo "apt-get install -f" >> scripts/install.sh
+      echo 'echo "deb http://archive.debian.org/debian jessie-backports main" >> /etc/apt/sources.list' >> scripts/install.sh
+      echo 'echo "Acquire::Check-Valid-Until \"false\";" > /etc/apt/apt.conf.d/100disablechecks' >> scripts/install.sh
+      echo 'apt-get -o Acquire::Check-Valid-Until=false update' >> scripts/install.sh
+      echo 'apt-get install -y -t jessie-backports openjdk-8-jre' >> scripts/install.sh
+      echo "install.sh updated"
+      cat scripts/install.sh
+      rsync -arv -e "ssh -i ssh_private_key" scripts/install.sh root@$VSI_HOST:app
+    {{/has}}
+
+    {{#has deployment.language 'SPRING'}}
+      rsync -arv -e "ssh -i ssh_private_key" {{name}}-0.0_1-1_all.deb root@$VSI_HOST:app
+      echo "scripts/install.sh initial"
+      cat scripts/install.sh
+      # https://unix.stackexchange.com/questions/508724/failed-to-fetch-jessie-backports-repository
+      echo "apt-get update" > scripts/install.sh
+      echo "apt-get install -f" >> scripts/install.sh
+      echo 'echo "deb http://archive.debian.org/debian jessie-backports main" >> /etc/apt/sources.list' >> scripts/install.sh
+      echo 'echo "Acquire::Check-Valid-Until \"false\";" > /etc/apt/apt.conf.d/100disablechecks' >> scripts/install.sh
+      echo 'apt-get -o Acquire::Check-Valid-Until=false update' >> scripts/install.sh
+      echo 'apt-get install -y -t jessie-backports openjdk-8-jre' >> scripts/install.sh
+      echo "install.sh updated"
+      cat scripts/install.sh
+      rsync -arv -e "ssh -i ssh_private_key" scripts/install.sh root@$VSI_HOST:app
+    {{/has}}
     docker_image: alpine
   - name: Install
     type: builder
@@ -190,7 +221,28 @@ stages:
       #!/bin/bash
       set -eo pipefail
       VSI_HOST=$(cat hostip.txt)
+
+    {{#has deployment.language 'JAVA'}}
+      ssh -o StrictHostKeyChecking=no -i ssh_private_key root@$VSI_HOST "rm -rf /usr/src/{{name}}; cd app; dpkg -i {{name}}-0.0_1-1_all.deb; source install.sh"
+    {{/has}}
+    {{#has deployment.language 'SPRING'}}
+      ssh -o StrictHostKeyChecking=no -i ssh_private_key root@$VSI_HOST "rm -rf /usr/src/{{name}}; cd app; dpkg -i {{name}}-0.0_1-1_all.deb; source install.sh"
+    {{/has}}
+    {{#has deployment.language 'NODE'}}
       ssh -o StrictHostKeyChecking=no -i ssh_private_key root@$VSI_HOST "rm -rf /usr/src/{{name}}; cd app; dpkg -i {{name}}-0.0_1-1_all.deb; cd /usr/src/{{name}}; source install.sh"
+    {{/has}}
+    {{#has deployment.language 'PYTHON'}}
+      ssh -o StrictHostKeyChecking=no -i ssh_private_key root@$VSI_HOST "rm -rf /usr/src/{{name}}; cd app; dpkg -i {{name}}-0.0_1-1_all.deb; cd /usr/src/{{name}}; source install.sh"
+    {{/has}}
+    {{#has deployment.language 'DJANGO'}}
+      ssh -o StrictHostKeyChecking=no -i ssh_private_key root@$VSI_HOST "rm -rf /usr/src/{{name}}; cd app; dpkg -i {{name}}-0.0_1-1_all.deb; cd /usr/src/{{name}}; source install.sh"
+    {{/has}}
+    {{#has deployment.language 'SWIFT'}}
+      ssh -o StrictHostKeyChecking=no -i ssh_private_key root@$VSI_HOST "rm -rf /usr/src/{{name}}; cd app; dpkg -i {{name}}-0.0_1-1_all.deb; cd /usr/src/{{name}}; source install.sh"
+    {{/has}}
+    {{#has deployment.language 'GO'}}
+      ssh -o StrictHostKeyChecking=no -i ssh_private_key root@$VSI_HOST "rm -rf /usr/src/{{name}}; cd app; dpkg -i {{name}}-0.0_1-1_all.deb; cd /usr/src/{{name}}; source install.sh"
+    {{/has}}
   - name: Start
     type: builder
     artifact_dir: ''
@@ -237,6 +289,10 @@ stages:
       {{#has deployment.language 'GO'}}
       PORT='8080'
       {{/has}}
+
+      # sleep for 10 seconds to allow enough time for the server to start
+      sleep 10
+
       if [ $(curl -sL -w "%{http_code}\\n" "http://${VSI_HOST}:${PORT}/{{#if healthEndpoint}}{{healthEndpoint}}{{else}}health{{/if}}" -o /dev/null --connect-timeout 3 --max-time 5 --retry 3 --retry-max-time 30) == "200" ]; then
         echo "Successfully reached health endpoint: http://${VSI_HOST}:${PORT}/{{#if healthEndpoint}}{{healthEndpoint}}{{else}}health{{/if}}"
         echo "====================================================================="

--- a/generators/vsi/templates/terraform/scripts/install_master.sh
+++ b/generators/vsi/templates/terraform/scripts/install_master.sh
@@ -3,8 +3,9 @@
 apt-get update
 apt-get install -f
 {{#has deployment.language 'NODE'}}
-wget -qO- "https://deb.nodesource.com/setup_8.x" | bash -;
-apt-get install -y nodejs
+wget -qO- "https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh" | bash -;
+source ~/.profile
+nvm install 8.16.0
 {{/has}}
 {{#has deployment.language 'PYTHON'}}
 apt-get install -y python3-pip


### PR DESCRIPTION
Patched vsi deployment for java projects (outdated os/dependency)

Patch is based on thread here: https://unix.stackexchange.com/questions/508724/failed-to-fetch-jessie-backports-repository

Long term fix will be to no longer use out of date versions.