### PR TITLE
fix: missing rsync for non-java vsi templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+<a name="1.7.15"></a>
+## [1.7.15](https://github.com/ibm-developer/generator-ibm-cloud-enablement/compare/v1.7.14...v1.7.15) (2019-04-18)
+
+
+### Bug Fixes
+
+* missing rsync for non-java vsi templates ([53a23fa](https://github.com/ibm-developer/generator-ibm-cloud-enablement/commit/53a23fa))
+
+
+
 <a name="1.7.14"></a>
 ## [1.7.14](https://github.com/ibm-developer/generator-ibm-cloud-enablement/compare/v1.7.13...v1.7.14) (2019-04-18)
 

--- a/generators/deployment/templates/vsi_pipeline_master.yml
+++ b/generators/deployment/templates/vsi_pipeline_master.yml
@@ -180,9 +180,9 @@ stages:
       apk add --no-cache openssh rsync
       VSI_HOST=$(cat hostip.txt)
       ssh -o StrictHostKeyChecking=no -i ssh_private_key root@$VSI_HOST "apt-get update; apt-get install rsync; mkdir -p app"
+      rsync -arv -e "ssh -i ssh_private_key" {{name}}-0.0_1-1_all.deb root@$VSI_HOST:app
 
     {{#has deployment.language 'JAVA'}}
-      rsync -arv -e "ssh -i ssh_private_key" {{name}}-0.0_1-1_all.deb root@$VSI_HOST:app
       echo "scripts/install.sh initial"
       cat scripts/install.sh
       # https://unix.stackexchange.com/questions/508724/failed-to-fetch-jessie-backports-repository
@@ -196,9 +196,7 @@ stages:
       cat scripts/install.sh
       rsync -arv -e "ssh -i ssh_private_key" scripts/install.sh root@$VSI_HOST:app
     {{/has}}
-
     {{#has deployment.language 'SPRING'}}
-      rsync -arv -e "ssh -i ssh_private_key" {{name}}-0.0_1-1_all.deb root@$VSI_HOST:app
       echo "scripts/install.sh initial"
       cat scripts/install.sh
       # https://unix.stackexchange.com/questions/508724/failed-to-fetch-jessie-backports-repository
@@ -212,6 +210,7 @@ stages:
       cat scripts/install.sh
       rsync -arv -e "ssh -i ssh_private_key" scripts/install.sh root@$VSI_HOST:app
     {{/has}}
+    
     docker_image: alpine
   - name: Install
     type: builder

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-ibm-cloud-enablement",
-  "version": "1.7.14",
+  "version": "1.7.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-ibm-cloud-enablement",
-  "version": "1.7.14",
+  "version": "1.7.15",
   "description": "This generator adds IBM Cloud enablement to applications",
   "main": "generators/app/index.js",
   "license": "Apache-2.0",


### PR DESCRIPTION
Moved `rsync` command out of java scope, so it runs for all language types in the `Deploy` stage