### PR TITLE
fix: update buildpack for go

### DIFF
--- a/generators/deployment/index.js
+++ b/generators/deployment/index.js
@@ -161,8 +161,7 @@ module.exports = class extends Generator {
 	}
 
 	_configureGo() {
-		// Need a direct github link becasue 'go_buildpack' doesn't have dep support
-		this.manifestConfig.buildpack = 'https://github.com/cloudfoundry/go-buildpack.git#v1.8.25';
+		this.manifestConfig.buildpack = 'go_buildpack';
 		this.manifestConfig.command = undefined;
 		this.manifestConfig.memory = this.manifestConfig.memory || '128M';
 		this.manifestConfig.env.GOPACKAGENAME = this.bluemix.sanitizedName;


### PR DESCRIPTION
The Go starter kits have been failing to deploy to CF recently, as the buildpack that they request used the legacy `cflinuxfs2` stack, while the current infrastructure defaults to `cflinuxfs3`.  I have updated this and removed the note about go_buildpack.  I am not certain whether the dependency support has changed, but making this change will fix the base case for the starter kits, and any service dependency issues can be addressed with #813.