### PR TITLE
fix: add app-id attribute for patterns flow

### DIFF
--- a/generators/dockertools/index.js
+++ b/generators/dockertools/index.js
@@ -155,7 +155,8 @@ module.exports = class extends Generator {
 			runCmd: '',
 			stopCmd: '',
 			debugCmd: `/swift-utils/tools-utils.sh debug ${executableName} 1024`,
-			chartPath: `chart/${applicationName.toLowerCase()}`
+			chartPath: `chart/${applicationName.toLowerCase()}`,
+			applicationId: `${this.bluemix.applicationId}`
 		};
 
 		// Create Docker config object for Swift
@@ -268,7 +269,8 @@ module.exports = class extends Generator {
 			runCmd: '',
 			debugCmd: 'npm run debug',
 			stopCmd: "npm stop",
-			chartPath: `chart/${applicationName.toLowerCase()}`
+			chartPath: `chart/${applicationName.toLowerCase()}`,
+			applicationId: `${this.bluemix.applicationId}`
 		};
 
 		this._writeHandlebarsFile('cli-config-common.yml', FILENAME_CLI_CONFIG, {cliConfig});
@@ -320,6 +322,7 @@ module.exports = class extends Generator {
 
 		if(!this.opts.platforms || this.opts.platforms.includes('cli')) {
 			/* Common cli-config template */
+			this.opts.applicationId = `${this.bluemix.applicationId}`;
 			if (this.fs.exists(this.destinationPath(FILENAME_CLI_CONFIG))){
 				this.log(FILENAME_CLI_CONFIG, "already exists, skipping.");
 			} else {
@@ -443,7 +446,8 @@ module.exports = class extends Generator {
 			debugCmd: this.opts.enable
 				? 'echo No debug command specified in cli-config'
 				: 'python manage.py debug',
-			chartPath: `chart/${applicationName.toLowerCase()}`
+			chartPath: `chart/${applicationName.toLowerCase()}`,
+			applicationId: `${this.bluemix.applicationId}`
 		};
 		const derrayify = serviceEnvs[0];
 
@@ -595,7 +599,8 @@ module.exports = class extends Generator {
 			debugCmd: this.opts.enable
 				? 'echo No debug command specified in cli-config'
 				: `python manage.py runserver --noreload`,
-			chartPath: `chart/${applicationName.toLowerCase()}`
+			chartPath: `chart/${applicationName.toLowerCase()}`,
+			applicationId: `${this.bluemix.applicationId}`
 		};
 
 		if (this.fs.exists(this.destinationPath(FILENAME_CLI_CONFIG))){
@@ -691,7 +696,8 @@ module.exports = class extends Generator {
 			runCmd: '',
 			stopCmd: '',
 			debugCmd: 'dlv debug --headless --listen=0.0.0.0:8181',
-			chartPath: `chart/${chartName}`
+			chartPath: `chart/${chartName}`,
+			applicationId: `${this.bluemix.applicationId}`
 		};
 
 		this._writeHandlebarsFile('cli-config-common.yml', FILENAME_CLI_CONFIG, {cliConfig});

--- a/generators/dockertools/templates/cli-config-common.yml
+++ b/generators/dockertools/templates/cli-config-common.yml
@@ -55,3 +55,6 @@ chart-path : "{{{cliConfig.chartPath}}}"
 
 # The IBM version of this configuration
 version : "0.0.3"
+{{#exists cliConfig.applicationId}}
+ibm-cloud-app-id : "{{{cliConfig.applicationId}}}"
+{{/exists}}

--- a/generators/dockertools/templates/java/cli-config.yml.template
+++ b/generators/dockertools/templates/java/cli-config.yml.template
@@ -1,5 +1,8 @@
 # The IBM version of this configuration
 version : 0.0.3
+{{#exists applicationId}}
+ibm-cloud-app-id : "{{applicationId}}"
+{{/exists}}
 
 # The container name used for the run container
 container-name-run : "{{#toLowerCase appName}}{{/toLowerCase}}"

--- a/generators/dockertools/templates/spring/cli-config.yml.template
+++ b/generators/dockertools/templates/spring/cli-config.yml.template
@@ -1,5 +1,8 @@
 # The IBM version of this configuration
 version : 0.0.3
+{{#exists applicationId}}
+ibm-cloud-app-id : "{{applicationId}}"
+{{/exists}}
 
 # The container name used for the run container
 container-name-run : "{{#toLowerCase appName}}{{/toLowerCase}}"

--- a/generators/lib/handlebars.js
+++ b/generators/lib/handlebars.js
@@ -93,5 +93,14 @@ Handlebars.registerHelper('checkProperty', function(context, options, handler) {
 	return undefined;
 });
 
+//only process the section if the paramter is not undefined
+Handlebars.registerHelper('exists', function(context, handler) {
+	if (context !== 'undefined') {
+		let data = Handlebars.createFrame(handler.data);
+		return handler.fn(handler.data.root, {data : data, blockParams : [handler.data.root]})
+	} else {
+		return undefined
+	}
+});
 
 module.exports = Handlebars;

--- a/package-lock.json
+++ b/package-lock.json
@@ -7000,7 +7000,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         },
         "ms": {

--- a/test/samples/scaffolder-sample-contents.js
+++ b/test/samples/scaffolder-sample-contents.js
@@ -255,6 +255,7 @@ class scaffolderSample {
 	noServices() {
 		return {
 			"name": "AcmeProject",
+			"applicationId": "c48blpm2-8ae9-4e43-a55f-7406b0346ef3",
 			"server": {
 				"diskQuota": "512M",
 				"domain": "ng.bluemix.net",

--- a/test/test-dockertools.js
+++ b/test/test-dockertools.js
@@ -140,6 +140,7 @@ describe('cloud-enablement:dockertools', function () {
 			assert.fileContent('cli-config.yml', 'container-port-map-debug : "2048:1024,2049:1025"');
 			assert.fileContent('cli-config.yml', 'dockerfile-run : "docker-compose.yml"');
 			assert.fileContent('cli-config.yml', 'dockerfile-tools : "docker-compose-tools.yml"');
+			assert.noFileContent('cli-config.yml', 'ibm-cloud-app-id :')
 		});
 
 		it('create dockerignore file', function () {
@@ -273,6 +274,7 @@ describe('cloud-enablement:dockertools', function () {
 				});
 				it('create cli-config for CLI tool', function () {
 					assert.file('cli-config.yml');
+					assert.noFileContent('cli-config.yml', 'ibm-cloud-app-id : ')
 				});
 				it('create cli-config chart path includes application name', function () {
 					assert.fileContent('cli-config.yml', `chart-path : "chart/${applicationName.toLowerCase()}"`);
@@ -534,6 +536,7 @@ describe('cloud-enablement:dockertools', function () {
 			assert.fileContent('cli-config.yml', 'python manage.py');
 			assert.fileContent('cli-config.yml', 'acmeproject-flask-run');
 			assert.fileContent('cli-config.yml', `chart-path : "chart/${applicationName.toLowerCase()}"`);
+			assert.fileContent('cli-config.yml', 'ibm-cloud-app-id : "c48blpm2-8ae9-4e43-a55f-7406b0346ef3"');
 		});
 
 		it('create manage.py file for flask', function () {
@@ -630,6 +633,7 @@ describe('cloud-enablement:dockertools', function () {
 			assert.fileContent('cli-config.yml', 'python manage.py');
 			assert.fileContent('cli-config.yml', 'acmeproject-flask-run');
 			assert.fileContent('cli-config.yml', `chart-path : "chart/${applicationName.toLowerCase()}"`);
+			assert.noFileContent('cli-config.yml', 'ibm-cloud-app-id : ');
 		});
 
 		it('create manage.py file for flask', function () {
@@ -776,6 +780,7 @@ describe('cloud-enablement:dockertools', function () {
 			assert.fileContent('cli-config.yml', `chart-path : "chart/${applicationName.toLowerCase()}"`);
 			assert.fileContent('cli-config.yml', 'dockerfile-run : "Dockerfile"');
 			assert.fileContent('cli-config.yml', 'dockerfile-tools : "Dockerfile-tools"');
+			assert.noFileContent('cli-config.yml', 'ibm-cloud-app-id : ');
 		});
 
 		it('create dockerignore file', function () {
@@ -816,6 +821,7 @@ describe('cloud-enablement:dockertools', function () {
 			assert.fileContent('cli-config.yml', `dockerfile-run : "docker-compose.yml"`);
 			assert.fileContent('cli-config.yml', `dockerfile-tools : "docker-compose-tools.yml"`);
 			assert.fileContent('cli-config.yml', `chart-path : "chart/${applicationName.toLowerCase()}"`);
+			assert.noFileContent('cli-config.yml', 'ibm-cloud-app-id : ');
 		});
 
 		it('create dockerignore file', function () {


### PR DESCRIPTION
These changes allow for the `bluemix.applicationId` attribute to be rendered in the **cli-config.yaml** only when it is provided.  This is to assist the patterns workflow in the CLI.