### PR TITLE
chore: rewrite deployment files for static apps

### DIFF
--- a/generators/dockertools/index.js
+++ b/generators/dockertools/index.js
@@ -36,7 +36,7 @@ module.exports = class extends Generator {
 			this.bluemix = opts.bluemix;
 		}
 
-		if(typeof (opts) === 'string'){
+		if (typeof (opts) === 'string') {
 			this.opts = JSON.parse(opts || '{}');
 		} else {
 			this.opts = opts.cloudContext || opts;
@@ -44,8 +44,8 @@ module.exports = class extends Generator {
 
 		this.opts.libertyBeta = opts.libertyBeta;
 
-		if (typeof(this.opts.services) === 'string') {
-			this.opts.services  = JSON.parse(opts.services || '[]');
+		if (typeof (this.opts.services) === 'string') {
+			this.opts.services = JSON.parse(opts.services || '[]');
 		} else {
 			this.opts.services = opts.services || [];
 		}
@@ -105,7 +105,7 @@ module.exports = class extends Generator {
 		let compilationOptions = "";
 		for (let index in servKeys) {
 			const servKey = servKeys[index];
-			if(this.bluemix.hasOwnProperty(servKey)) {
+			if (this.bluemix.hasOwnProperty(servKey)) {
 				serviceItems.push(services[servKey]);
 				if (services[servKey].hasOwnProperty("compilationOptions")) {
 					compilationOptions = compilationOptions + " " + services[servKey].compilationOptions;
@@ -113,19 +113,19 @@ module.exports = class extends Generator {
 			}
 		}
 
-        // Iterate over services key deployed under docker images
+		// Iterate over services key deployed under docker images
 		// Retrieve envs, port and images names if availables for each services
-		for (let index = 0; index < this.opts.services.length; index++){
+		for (let index = 0; index < this.opts.services.length; index++) {
 			const servKey = this.opts.services[index];
-			if(services[servKey].hasOwnProperty('envs')){
+			if (services[servKey].hasOwnProperty('envs')) {
 				serviceEnvs.push(services[servKey].envs);
 			}
 
-			if(services[servKey].hasOwnProperty('imageName')){
+			if (services[servKey].hasOwnProperty('imageName')) {
 				serviceImageNames.push(services[servKey].imageName);
 			}
 
-			if(services[servKey].hasOwnProperty('port')){
+			if (services[servKey].hasOwnProperty('port')) {
 				servicePorts.push(services[servKey].port);
 			}
 		}
@@ -164,7 +164,7 @@ module.exports = class extends Generator {
 			serviceItems: serviceItems
 		}
 
-		this._writeHandlebarsFile('cli-config-common.yml', FILENAME_CLI_CONFIG, {cliConfig});
+		this._writeHandlebarsFile('cli-config-common.yml', FILENAME_CLI_CONFIG, { cliConfig });
 
 		this._writeHandlebarsFile('swift/Dockerfile', FILENAME_DOCKERFILE, dockerConfig);
 
@@ -182,8 +182,8 @@ module.exports = class extends Generator {
 		}
 
 		const derrayify = serviceEnvs[0];
-		if(this.opts.services.length > 0){
-			const dockerComposeConfig =  {
+		if (this.opts.services.length > 0) {
+			const dockerComposeConfig = {
 				containerName: `${applicationName.toLowerCase()}-swift-run`,
 				image: `${applicationName.toLowerCase()}-swift-run`,
 				envs: derrayify,
@@ -230,18 +230,18 @@ module.exports = class extends Generator {
 			}
 		}
 
-          // Iterate over services key deployed under docker images
-          // Retrieve envs, port and images names if availables for each services
-		for (let index = 0; index < this.opts.services.length; index++){
+		// Iterate over services key deployed under docker images
+		// Retrieve envs, port and images names if availables for each services
+		for (let index = 0; index < this.opts.services.length; index++) {
 			const servKey = this.opts.services[index];
-			if(services[servKey].hasOwnProperty('envs')){
+			if (services[servKey].hasOwnProperty('envs')) {
 				serviceEnvs.push(services[servKey].envs);
 			}
 
-			if(services[servKey].hasOwnProperty('imageName')){
+			if (services[servKey].hasOwnProperty('imageName')) {
 				serviceImageNames.push(services[servKey].imageName);
 			}
-			if(services[servKey].hasOwnProperty('port')){
+			if (services[servKey].hasOwnProperty('port')) {
 				servicePorts.push(services[servKey].port);
 			}
 		}
@@ -262,7 +262,7 @@ module.exports = class extends Generator {
 			dockerFileTools,
 			imageNameRun: `${applicationName.toLowerCase()}-express-run`,
 			imageNameTools: `${applicationName.toLowerCase()}-express-tools`,
-			buildCmdRun: 'npm install' ,
+			buildCmdRun: 'npm install',
 			testCmd: 'npm run test',
 			buildCmdDebug: 'npm install',
 			runCmd: '',
@@ -271,23 +271,23 @@ module.exports = class extends Generator {
 			chartPath: `chart/${applicationName.toLowerCase()}`
 		};
 
-		this._writeHandlebarsFile('cli-config-common.yml', FILENAME_CLI_CONFIG, {cliConfig});
+		this._writeHandlebarsFile('cli-config-common.yml', FILENAME_CLI_CONFIG, { cliConfig });
 
-		this._writeHandlebarsFile('node/Dockerfile', FILENAME_DOCKERFILE, {port, servicesPackages});
+		this._writeHandlebarsFile('node/Dockerfile', FILENAME_DOCKERFILE, { port, servicesPackages });
 
-		this._writeHandlebarsFile('node/Dockerfile-tools', FILENAME_DOCKERFILE_TOOLS, {port, servicesPackages, debugPort});
+		this._writeHandlebarsFile('node/Dockerfile-tools', FILENAME_DOCKERFILE_TOOLS, { port, servicesPackages, debugPort });
 
 		this._copyTemplateIfNotExists(FILENAME_DOCKER_IGNORE, 'node/dockerignore', {});
 
-		this._copyTemplateIfNotExists(FILENAME_DEBUG , 'node/run-debug', {});
+		this._copyTemplateIfNotExists(FILENAME_DEBUG, 'node/run-debug', {});
 
-		this._copyTemplateIfNotExists(FILENAME_DEV , 'node/run-dev', {});
+		this._copyTemplateIfNotExists(FILENAME_DEV, 'node/run-dev', {});
 
 
-		if(this.opts.services.length > 0){
+		if (this.opts.services.length > 0) {
 
 			const derrayify = serviceEnvs[0];
-			const dockerComposeConfig =  {
+			const dockerComposeConfig = {
 				containerName: `${applicationName.toLowerCase()}-express-run`,
 				image: `${applicationName.toLowerCase()}-express-run`,
 				ports: [port, debugPort].concat(servicePorts),
@@ -298,11 +298,11 @@ module.exports = class extends Generator {
 			this._writeHandlebarsFile('node/docker-compose.yml', FILENAME_DOCKERCOMPOSE, dockerComposeConfig);
 			dockerComposeConfig.containerName = `${applicationName.toLowerCase()}-express-tools`;
 			dockerComposeConfig.image = `${applicationName.toLowerCase()}-express-tools`,
-			this._writeHandlebarsFile('node/docker-compose-tools.yml', FILENAME_DOCKERCOMPOSE_TOOLS, dockerComposeConfig);
+				this._writeHandlebarsFile('node/docker-compose-tools.yml', FILENAME_DOCKERCOMPOSE_TOOLS, dockerComposeConfig);
 		}
 
 
-		if (this.fs.exists(this.destinationPath(FILENAME_DOCKER_IGNORE))){
+		if (this.fs.exists(this.destinationPath(FILENAME_DOCKER_IGNORE))) {
 			this.log(FILENAME_DOCKER_IGNORE, "already exists, skipping.");
 		} else {
 			this.fs.copyTpl(
@@ -313,14 +313,14 @@ module.exports = class extends Generator {
 	}
 
 	_generateJava() {
-		if(!this.opts.appName) {
+		if (!this.opts.appName) {
 			this.opts.appName = Utils.sanitizeAlphaNum(this.bluemix.name);
 		}
 		let dir = this.bluemix.backendPlatform.toLowerCase();
 
-		if(!this.opts.platforms || this.opts.platforms.includes('cli')) {
+		if (!this.opts.platforms || this.opts.platforms.includes('cli')) {
 			/* Common cli-config template */
-			if (this.fs.exists(this.destinationPath(FILENAME_CLI_CONFIG))){
+			if (this.fs.exists(this.destinationPath(FILENAME_CLI_CONFIG))) {
 				this.log(FILENAME_CLI_CONFIG, "already exists, skipping.");
 			} else {
 				this._writeHandlebarsFile(
@@ -330,7 +330,7 @@ module.exports = class extends Generator {
 				);
 			}
 
-			if (this.fs.exists(this.destinationPath(FILENAME_DOCKERFILE_TOOLS))){
+			if (this.fs.exists(this.destinationPath(FILENAME_DOCKERFILE_TOOLS))) {
 				this.log(FILENAME_DOCKERFILE_TOOLS, "already exists, skipping.");
 			} else {
 				this._writeHandlebarsFile(
@@ -341,7 +341,7 @@ module.exports = class extends Generator {
 			}
 		}
 
-		if (this.fs.exists(this.destinationPath(FILENAME_DOCKERFILE))){
+		if (this.fs.exists(this.destinationPath(FILENAME_DOCKERFILE))) {
 			this.log(FILENAME_DOCKERFILE, "already exists, skipping.");
 		} else {
 			this._writeHandlebarsFile(
@@ -351,7 +351,7 @@ module.exports = class extends Generator {
 			);
 		}
 
-		if (this.fs.exists(this.destinationPath(FILENAME_DOCKER_IGNORE))){
+		if (this.fs.exists(this.destinationPath(FILENAME_DOCKER_IGNORE))) {
 			this.log(FILENAME_DOCKER_IGNORE, "already exists, skipping.")
 		} else {
 			this._writeHandlebarsFile(
@@ -364,15 +364,10 @@ module.exports = class extends Generator {
 
 	_writeHandlebarsFile(templateFile, destinationFile, data) {
 
-		if (this.fs.exists(this.destinationPath(destinationFile))) {
-			this.log(destinationFile, "already exists, skipping.");
-		}
-		else {
-			let template = this.fs.read(this.templatePath(templateFile));
-			let compiledTemplate = Handlebars.compile(template);
-			let output = compiledTemplate(data);
-			this.fs.write(this.destinationPath(destinationFile), output);
-		}
+		let template = this.fs.read(this.templatePath(templateFile));
+		let compiledTemplate = Handlebars.compile(template);
+		let output = compiledTemplate(data);
+		this.fs.write(this.destinationPath(destinationFile), output);
 	}
 
 	_generatePython() {
@@ -404,17 +399,17 @@ module.exports = class extends Generator {
 			}
 		}
 
-        // Iterate over services key deployed under docker images
+		// Iterate over services key deployed under docker images
 		// Retrieve envs, port and images names if availables for each services
-		for (let index = 0; index < this.opts.services.length; index++){
+		for (let index = 0; index < this.opts.services.length; index++) {
 			const servKey = this.opts.services[index];
-			if(services[servKey].hasOwnProperty('envs')){
+			if (services[servKey].hasOwnProperty('envs')) {
 				serviceEnvs.push(services[servKey].envs);
 			}
-			if(services[servKey].hasOwnProperty('imageName')){
+			if (services[servKey].hasOwnProperty('imageName')) {
 				serviceImageNames.push(services[servKey].imageName);
 			}
-			if(services[servKey].hasOwnProperty('port')){
+			if (services[servKey].hasOwnProperty('port')) {
 				servicePorts.push(services[servKey].port);
 			}
 
@@ -447,8 +442,8 @@ module.exports = class extends Generator {
 		};
 		const derrayify = serviceEnvs[0];
 
-		if(this.opts.services.length > 0){
-			const dockerComposeConfig =  {
+		if (this.opts.services.length > 0) {
+			const dockerComposeConfig = {
 				containerName: `${applicationName.toLowerCase()}-flask-run`,
 				image: `${applicationName.toLowerCase()}-flask-run`,
 				ports: [port, debugPort].concat(servicePorts),
@@ -462,13 +457,13 @@ module.exports = class extends Generator {
 			this._writeHandlebarsFile('python/docker-compose-tools.yml', FILENAME_DOCKERCOMPOSE_TOOLS, dockerComposeConfig);
 		}
 
-		if (this.fs.exists(this.destinationPath(FILENAME_CLI_CONFIG))){
+		if (this.fs.exists(this.destinationPath(FILENAME_CLI_CONFIG))) {
 			this.log(FILENAME_CLI_CONFIG, "already exists, skipping.");
 		} else {
-			this._writeHandlebarsFile('cli-config-common.yml', FILENAME_CLI_CONFIG, {cliConfig});
+			this._writeHandlebarsFile('cli-config-common.yml', FILENAME_CLI_CONFIG, { cliConfig });
 		}
 
-		if (this.fs.exists(this.destinationPath(FILENAME_DOCKERFILE))){
+		if (this.fs.exists(this.destinationPath(FILENAME_DOCKERFILE))) {
 			this.log(FILENAME_DOCKERFILE, "already exists, skipping.");
 		} else {
 			this._writeHandlebarsFile('python/Dockerfile', FILENAME_DOCKERFILE, {
@@ -480,7 +475,7 @@ module.exports = class extends Generator {
 			});
 		}
 
-		if (this.fs.exists(this.destinationPath(FILENAME_DOCKERFILE_TOOLS))){
+		if (this.fs.exists(this.destinationPath(FILENAME_DOCKERFILE_TOOLS))) {
 			this.log(FILENAME_DOCKERFILE_TOOLS, "already exists, skipping.");
 		} else {
 			this._writeHandlebarsFile('python/Dockerfile-tools', FILENAME_DOCKERFILE_TOOLS, {
@@ -490,7 +485,7 @@ module.exports = class extends Generator {
 			});
 		}
 
-		if (this.fs.exists(this.destinationPath(FILENAME_DEV))){
+		if (this.fs.exists(this.destinationPath(FILENAME_DEV))) {
 			this.log(FILENAME_DEV, "already exists, skipping.");
 		} else {
 			this._writeHandlebarsFile('python/run-dev', FILENAME_DEV, {
@@ -504,7 +499,7 @@ module.exports = class extends Generator {
 
 		const FILENAME_MANAGEMENT = "manage.py";
 		if (!this.opts.enable) {
-			if (this.fs.exists(this.destinationPath(FILENAME_MANAGEMENT))){
+			if (this.fs.exists(this.destinationPath(FILENAME_MANAGEMENT))) {
 				this.log(FILENAME_MANAGEMENT, "already exists, skipping.");
 			} else {
 				this.fs.copy(
@@ -550,23 +545,23 @@ module.exports = class extends Generator {
 
 		}
 
-        // Iterate over services key deployed under docker images
+		// Iterate over services key deployed under docker images
 		// Retrieve envs, port and images names if availables for each services
-		for (let index = 0; index < this.opts.services.length; index++){
+		for (let index = 0; index < this.opts.services.length; index++) {
 			const servKey = this.opts.services[index];
 
-			if(services[servKey].hasOwnProperty('envs')){
+			if (services[servKey].hasOwnProperty('envs')) {
 				serviceEnvs.push(services[servKey].envs);
 			}
 
-			if(services[servKey].hasOwnProperty('imageName')){
+			if (services[servKey].hasOwnProperty('imageName')) {
 				serviceImageNames.push(services[servKey].imageName);
 			}
 
-			if(services[servKey].hasOwnProperty('imageName')){
+			if (services[servKey].hasOwnProperty('imageName')) {
 				serviceImageNames.push(services[servKey].imageName);
 			}
-			if(services[servKey].hasOwnProperty('port')){
+			if (services[servKey].hasOwnProperty('port')) {
 
 				servicePorts.push(services[servKey].port);
 			}
@@ -598,7 +593,7 @@ module.exports = class extends Generator {
 			chartPath: `chart/${applicationName.toLowerCase()}`
 		};
 
-		if (this.fs.exists(this.destinationPath(FILENAME_CLI_CONFIG))){
+		if (this.fs.exists(this.destinationPath(FILENAME_CLI_CONFIG))) {
 			this.log(FILENAME_CLI_CONFIG, "already exists, skipping.");
 		} else {
 			this._writeHandlebarsFile('cli-config-common.yml', FILENAME_CLI_CONFIG, {
@@ -607,7 +602,7 @@ module.exports = class extends Generator {
 			);
 		}
 
-		if (this.fs.exists(this.destinationPath(FILENAME_DOCKERFILE))){
+		if (this.fs.exists(this.destinationPath(FILENAME_DOCKERFILE))) {
 			this.log(FILENAME_DOCKERFILE, "already exists, skipping.");
 		} else {
 			this._writeHandlebarsFile('python/Dockerfile', FILENAME_DOCKERFILE, {
@@ -619,7 +614,7 @@ module.exports = class extends Generator {
 			});
 		}
 
-		if (this.fs.exists(this.destinationPath(FILENAME_DOCKERFILE_TOOLS))){
+		if (this.fs.exists(this.destinationPath(FILENAME_DOCKERFILE_TOOLS))) {
 			this.log(FILENAME_DOCKERFILE_TOOLS, "already exists, skipping.");
 		} else {
 			this._writeHandlebarsFile('python/Dockerfile-tools', FILENAME_DOCKERFILE_TOOLS, {
@@ -629,7 +624,7 @@ module.exports = class extends Generator {
 			});
 		}
 
-		if (this.fs.exists(this.destinationPath(FILENAME_DEV))){
+		if (this.fs.exists(this.destinationPath(FILENAME_DEV))) {
 			this.log(FILENAME_DEV, "already exists, skipping.");
 		} else {
 			this._writeHandlebarsFile('python/run-dev', FILENAME_DEV, {
@@ -641,8 +636,8 @@ module.exports = class extends Generator {
 			});
 		}
 
-		if(this.opts.services.length > 0){
-			const dockerComposeConfig =  {
+		if (this.opts.services.length > 0) {
+			const dockerComposeConfig = {
 				containerName: `${applicationName.toLowerCase()}-django-run`,
 				image: `${applicationName.toLowerCase()}-django-run`,
 				ports: [port, debugPort].concat(servicePorts),
@@ -694,7 +689,7 @@ module.exports = class extends Generator {
 			chartPath: `chart/${chartName}`
 		};
 
-		this._writeHandlebarsFile('cli-config-common.yml', FILENAME_CLI_CONFIG, {cliConfig});
+		this._writeHandlebarsFile('cli-config-common.yml', FILENAME_CLI_CONFIG, { cliConfig });
 
 		this._writeHandlebarsFile('go/Dockerfile', FILENAME_DOCKERFILE, { port, applicationName });
 
@@ -702,7 +697,7 @@ module.exports = class extends Generator {
 
 		this._copyTemplateIfNotExists(FILENAME_DOCKER_IGNORE, 'go/dockerignore', {});
 
-		if (this.fs.exists(this.destinationPath(FILENAME_DOCKER_IGNORE))){
+		if (this.fs.exists(this.destinationPath(FILENAME_DOCKER_IGNORE))) {
 			this.log(FILENAME_DOCKER_IGNORE, "already exists, skipping.");
 		} else {
 			this.fs.copyTpl(
@@ -713,7 +708,7 @@ module.exports = class extends Generator {
 	}
 
 	_copyTemplateIfNotExists(targetFileName, sourceTemplatePath, ctx) {
-		if (this.fs.exists(this.destinationPath(targetFileName))){
+		if (this.fs.exists(this.destinationPath(targetFileName))) {
 			this.log(targetFileName, "already exists, skipping.");
 		} else {
 			this.fs.copyTpl(


### PR DESCRIPTION
Changes to the `_writeHandlebarsFile` method to re-write a file if it exists already. This is important for the static starter kits where cloud enablement is run after app creation and the developer might have renamed the app.