### PR TITLE
Updated artifacts for pattern-type starter kits

### DIFF
--- a/generators/deployment/index.js
+++ b/generators/deployment/index.js
@@ -16,6 +16,7 @@
 const Handlebars = require('../lib/handlebars.js');
 const Generator = require('yeoman-generator');
 const Utils = require('../lib/utils');
+const xmljs = require('xml-js');
 
 module.exports = class extends Generator {
 	constructor(args, opts) {
@@ -180,6 +181,17 @@ module.exports = class extends Generator {
 		if (this.opts.appName) {
 			this.manifestConfig.name = this.opts.appName;
 			this.name = this.opts.appName;
+		}
+		if (!this.opts.artifactId) {
+			try {
+				const data = this.fs.read(this.templatePath("pom.xml"));
+				const pomJson = xmljs.xml2json(data, { compact: true, spaces: 4 })
+				const pom = JSON.parse(pomJson);
+				this.opts.artifactId = pom.project.artifactId._text;
+			} catch (err) {
+				// file not found
+				this.opts.artifactId = "<replace-me-with-artifactId-from-pom.xml>";
+			}
 		}
 		if (this.opts.createType === 'bff/liberty') {
 			this.manifestConfig.env.OPENAPI_SPEC = `/${this.name}/swagger/api`;

--- a/generators/dockertools/index.js
+++ b/generators/dockertools/index.js
@@ -16,6 +16,7 @@
 const Generator = require('yeoman-generator');
 const Handlebars = require('../lib/handlebars.js');
 const Utils = require('../lib/utils');
+const xmljs = require('xml-js');
 
 const FILENAME_CLI_CONFIG = "cli-config.yml";
 const FILENAME_DOCKERFILE = "Dockerfile";
@@ -36,7 +37,7 @@ module.exports = class extends Generator {
 			this.bluemix = opts.bluemix;
 		}
 
-		if(typeof (opts) === 'string'){
+		if (typeof (opts) === 'string') {
 			this.opts = JSON.parse(opts || '{}');
 		} else {
 			this.opts = opts.cloudContext || opts;
@@ -44,8 +45,8 @@ module.exports = class extends Generator {
 
 		this.opts.libertyBeta = opts.libertyBeta;
 
-		if (typeof(this.opts.services) === 'string') {
-			this.opts.services  = JSON.parse(opts.services || '[]');
+		if (typeof (this.opts.services) === 'string') {
+			this.opts.services = JSON.parse(opts.services || '[]');
 		} else {
 			this.opts.services = opts.services || [];
 		}
@@ -105,7 +106,7 @@ module.exports = class extends Generator {
 		let compilationOptions = "";
 		for (let index in servKeys) {
 			const servKey = servKeys[index];
-			if(this.bluemix.hasOwnProperty(servKey)) {
+			if (this.bluemix.hasOwnProperty(servKey)) {
 				serviceItems.push(services[servKey]);
 				if (services[servKey].hasOwnProperty("compilationOptions")) {
 					compilationOptions = compilationOptions + " " + services[servKey].compilationOptions;
@@ -113,23 +114,22 @@ module.exports = class extends Generator {
 			}
 		}
 
-        // Iterate over services key deployed under docker images
+		// Iterate over services key deployed under docker images
 		// Retrieve envs, port and images names if availables for each services
-		for (let index = 0; index < this.opts.services.length; index++){
+		for (let index = 0; index < this.opts.services.length; index++) {
 			const servKey = this.opts.services[index];
-			if(services[servKey].hasOwnProperty('envs')){
+			if (services[servKey].hasOwnProperty('envs')) {
 				serviceEnvs.push(services[servKey].envs);
 			}
 
-			if(services[servKey].hasOwnProperty('imageName')){
+			if (services[servKey].hasOwnProperty('imageName')) {
 				serviceImageNames.push(services[servKey].imageName);
 			}
 
-			if(services[servKey].hasOwnProperty('port')){
+			if (services[servKey].hasOwnProperty('port')) {
 				servicePorts.push(services[servKey].port);
 			}
 		}
-
 
 		compilationOptions = compilationOptions.trim();
 
@@ -165,7 +165,7 @@ module.exports = class extends Generator {
 			serviceItems: serviceItems
 		}
 
-		this._writeHandlebarsFile('cli-config-common.yml', FILENAME_CLI_CONFIG, {cliConfig});
+		this._writeHandlebarsFile('cli-config-common.yml', FILENAME_CLI_CONFIG, { cliConfig });
 
 		this._writeHandlebarsFile('swift/Dockerfile', FILENAME_DOCKERFILE, dockerConfig);
 
@@ -183,8 +183,8 @@ module.exports = class extends Generator {
 		}
 
 		const derrayify = serviceEnvs[0];
-		if(this.opts.services.length > 0){
-			const dockerComposeConfig =  {
+		if (this.opts.services.length > 0) {
+			const dockerComposeConfig = {
 				containerName: `${applicationName.toLowerCase()}-swift-run`,
 				image: `${applicationName.toLowerCase()}-swift-run`,
 				envs: derrayify,
@@ -231,18 +231,18 @@ module.exports = class extends Generator {
 			}
 		}
 
-          // Iterate over services key deployed under docker images
-          // Retrieve envs, port and images names if availables for each services
-		for (let index = 0; index < this.opts.services.length; index++){
+		// Iterate over services key deployed under docker images
+		// Retrieve envs, port and images names if availables for each services
+		for (let index = 0; index < this.opts.services.length; index++) {
 			const servKey = this.opts.services[index];
-			if(services[servKey].hasOwnProperty('envs')){
+			if (services[servKey].hasOwnProperty('envs')) {
 				serviceEnvs.push(services[servKey].envs);
 			}
 
-			if(services[servKey].hasOwnProperty('imageName')){
+			if (services[servKey].hasOwnProperty('imageName')) {
 				serviceImageNames.push(services[servKey].imageName);
 			}
-			if(services[servKey].hasOwnProperty('port')){
+			if (services[servKey].hasOwnProperty('port')) {
 				servicePorts.push(services[servKey].port);
 			}
 		}
@@ -263,7 +263,7 @@ module.exports = class extends Generator {
 			dockerFileTools,
 			imageNameRun: `${applicationName.toLowerCase()}-express-run`,
 			imageNameTools: `${applicationName.toLowerCase()}-express-tools`,
-			buildCmdRun: 'npm install' ,
+			buildCmdRun: 'npm install',
 			testCmd: 'npm run test',
 			buildCmdDebug: 'npm install',
 			runCmd: '',
@@ -273,23 +273,23 @@ module.exports = class extends Generator {
 			applicationId: `${this.bluemix.applicationId}`
 		};
 
-		this._writeHandlebarsFile('cli-config-common.yml', FILENAME_CLI_CONFIG, {cliConfig});
+		this._writeHandlebarsFile('cli-config-common.yml', FILENAME_CLI_CONFIG, { cliConfig });
 
-		this._writeHandlebarsFile('node/Dockerfile', FILENAME_DOCKERFILE, {port, servicesPackages});
+		this._writeHandlebarsFile('node/Dockerfile', FILENAME_DOCKERFILE, { port, servicesPackages });
 
-		this._writeHandlebarsFile('node/Dockerfile-tools', FILENAME_DOCKERFILE_TOOLS, {port, servicesPackages, debugPort});
+		this._writeHandlebarsFile('node/Dockerfile-tools', FILENAME_DOCKERFILE_TOOLS, { port, servicesPackages, debugPort });
 
 		this._copyTemplateIfNotExists(FILENAME_DOCKER_IGNORE, 'node/dockerignore', {});
 
-		this._copyTemplateIfNotExists(FILENAME_DEBUG , 'node/run-debug', {});
+		this._copyTemplateIfNotExists(FILENAME_DEBUG, 'node/run-debug', {});
 
-		this._copyTemplateIfNotExists(FILENAME_DEV , 'node/run-dev', {});
+		this._copyTemplateIfNotExists(FILENAME_DEV, 'node/run-dev', {});
 
 
-		if(this.opts.services.length > 0){
+		if (this.opts.services.length > 0) {
 
 			const derrayify = serviceEnvs[0];
-			const dockerComposeConfig =  {
+			const dockerComposeConfig = {
 				containerName: `${applicationName.toLowerCase()}-express-run`,
 				image: `${applicationName.toLowerCase()}-express-run`,
 				ports: [port, debugPort].concat(servicePorts),
@@ -299,12 +299,12 @@ module.exports = class extends Generator {
 			};
 			this._writeHandlebarsFile('node/docker-compose.yml', FILENAME_DOCKERCOMPOSE, dockerComposeConfig);
 			dockerComposeConfig.containerName = `${applicationName.toLowerCase()}-express-tools`;
-			dockerComposeConfig.image = `${applicationName.toLowerCase()}-express-tools`,
+			dockerComposeConfig.image = `${applicationName.toLowerCase()}-express-tools`;
 			this._writeHandlebarsFile('node/docker-compose-tools.yml', FILENAME_DOCKERCOMPOSE_TOOLS, dockerComposeConfig);
 		}
 
 
-		if (this.fs.exists(this.destinationPath(FILENAME_DOCKER_IGNORE))){
+		if (this.fs.exists(this.destinationPath(FILENAME_DOCKER_IGNORE))) {
 			this.log(FILENAME_DOCKER_IGNORE, "already exists, skipping.");
 		} else {
 			this.fs.copyTpl(
@@ -315,15 +315,33 @@ module.exports = class extends Generator {
 	}
 
 	_generateJava() {
-		if(!this.opts.appName) {
+
+		if (!this.opts.artifactId) {
+			try {
+				const data = this.fs.read(this.templatePath("pom.xml"));
+				const pomJson = xmljs.xml2json(data, { compact: true, spaces: 4 })
+				const pom = JSON.parse(pomJson);
+				this.opts.artifactId = pom.project.artifactId._text;
+			} catch (err) {
+				// file not found
+				this.opts.artifactId = "<replace-me-with-artifactId-from-pom.xml>";
+			}
+		} 
+
+		if (!this.opts.appName) {
 			this.opts.appName = Utils.sanitizeAlphaNum(this.bluemix.name);
 		}
 		let dir = this.bluemix.backendPlatform.toLowerCase();
 
-		if(!this.opts.platforms || this.opts.platforms.includes('cli')) {
+		this.opts.appNameRefreshed = this.bluemix.name.toLowerCase();
+		this.opts.buildType = this.opts.buildType ? this.opts.buildType : 'maven';
+		this.opts.version = this.opts.version ? this.opts.version : "1.0-SNAPSHOT";
+
+		if (!this.opts.platforms || this.opts.platforms.includes('cli')) {
 			/* Common cli-config template */
 			this.opts.applicationId = `${this.bluemix.applicationId}`;
-			if (this.fs.exists(this.destinationPath(FILENAME_CLI_CONFIG))){
+
+			if (this.fs.exists(this.destinationPath(FILENAME_CLI_CONFIG))) {
 				this.log(FILENAME_CLI_CONFIG, "already exists, skipping.");
 			} else {
 				this._writeHandlebarsFile(
@@ -333,7 +351,7 @@ module.exports = class extends Generator {
 				);
 			}
 
-			if (this.fs.exists(this.destinationPath(FILENAME_DOCKERFILE_TOOLS))){
+			if (this.fs.exists(this.destinationPath(FILENAME_DOCKERFILE_TOOLS))) {
 				this.log(FILENAME_DOCKERFILE_TOOLS, "already exists, skipping.");
 			} else {
 				this._writeHandlebarsFile(
@@ -344,7 +362,7 @@ module.exports = class extends Generator {
 			}
 		}
 
-		if (this.fs.exists(this.destinationPath(FILENAME_DOCKERFILE))){
+		if (this.fs.exists(this.destinationPath(FILENAME_DOCKERFILE))) {
 			this.log(FILENAME_DOCKERFILE, "already exists, skipping.");
 		} else {
 			this._writeHandlebarsFile(
@@ -354,7 +372,7 @@ module.exports = class extends Generator {
 			);
 		}
 
-		if (this.fs.exists(this.destinationPath(FILENAME_DOCKER_IGNORE))){
+		if (this.fs.exists(this.destinationPath(FILENAME_DOCKER_IGNORE))) {
 			this.log(FILENAME_DOCKER_IGNORE, "already exists, skipping.")
 		} else {
 			this._writeHandlebarsFile(
@@ -407,17 +425,17 @@ module.exports = class extends Generator {
 			}
 		}
 
-        // Iterate over services key deployed under docker images
+		// Iterate over services key deployed under docker images
 		// Retrieve envs, port and images names if availables for each services
-		for (let index = 0; index < this.opts.services.length; index++){
+		for (let index = 0; index < this.opts.services.length; index++) {
 			const servKey = this.opts.services[index];
-			if(services[servKey].hasOwnProperty('envs')){
+			if (services[servKey].hasOwnProperty('envs')) {
 				serviceEnvs.push(services[servKey].envs);
 			}
-			if(services[servKey].hasOwnProperty('imageName')){
+			if (services[servKey].hasOwnProperty('imageName')) {
 				serviceImageNames.push(services[servKey].imageName);
 			}
-			if(services[servKey].hasOwnProperty('port')){
+			if (services[servKey].hasOwnProperty('port')) {
 				servicePorts.push(services[servKey].port);
 			}
 
@@ -451,8 +469,8 @@ module.exports = class extends Generator {
 		};
 		const derrayify = serviceEnvs[0];
 
-		if(this.opts.services.length > 0){
-			const dockerComposeConfig =  {
+		if (this.opts.services.length > 0) {
+			const dockerComposeConfig = {
 				containerName: `${applicationName.toLowerCase()}-flask-run`,
 				image: `${applicationName.toLowerCase()}-flask-run`,
 				ports: [port, debugPort].concat(servicePorts),
@@ -466,13 +484,13 @@ module.exports = class extends Generator {
 			this._writeHandlebarsFile('python/docker-compose-tools.yml', FILENAME_DOCKERCOMPOSE_TOOLS, dockerComposeConfig);
 		}
 
-		if (this.fs.exists(this.destinationPath(FILENAME_CLI_CONFIG))){
+		if (this.fs.exists(this.destinationPath(FILENAME_CLI_CONFIG))) {
 			this.log(FILENAME_CLI_CONFIG, "already exists, skipping.");
 		} else {
-			this._writeHandlebarsFile('cli-config-common.yml', FILENAME_CLI_CONFIG, {cliConfig});
+			this._writeHandlebarsFile('cli-config-common.yml', FILENAME_CLI_CONFIG, { cliConfig });
 		}
 
-		if (this.fs.exists(this.destinationPath(FILENAME_DOCKERFILE))){
+		if (this.fs.exists(this.destinationPath(FILENAME_DOCKERFILE))) {
 			this.log(FILENAME_DOCKERFILE, "already exists, skipping.");
 		} else {
 			this._writeHandlebarsFile('python/Dockerfile', FILENAME_DOCKERFILE, {
@@ -484,7 +502,7 @@ module.exports = class extends Generator {
 			});
 		}
 
-		if (this.fs.exists(this.destinationPath(FILENAME_DOCKERFILE_TOOLS))){
+		if (this.fs.exists(this.destinationPath(FILENAME_DOCKERFILE_TOOLS))) {
 			this.log(FILENAME_DOCKERFILE_TOOLS, "already exists, skipping.");
 		} else {
 			this._writeHandlebarsFile('python/Dockerfile-tools', FILENAME_DOCKERFILE_TOOLS, {
@@ -494,7 +512,7 @@ module.exports = class extends Generator {
 			});
 		}
 
-		if (this.fs.exists(this.destinationPath(FILENAME_DEV))){
+		if (this.fs.exists(this.destinationPath(FILENAME_DEV))) {
 			this.log(FILENAME_DEV, "already exists, skipping.");
 		} else {
 			this._writeHandlebarsFile('python/run-dev', FILENAME_DEV, {
@@ -508,7 +526,7 @@ module.exports = class extends Generator {
 
 		const FILENAME_MANAGEMENT = "manage.py";
 		if (!this.opts.enable) {
-			if (this.fs.exists(this.destinationPath(FILENAME_MANAGEMENT))){
+			if (this.fs.exists(this.destinationPath(FILENAME_MANAGEMENT))) {
 				this.log(FILENAME_MANAGEMENT, "already exists, skipping.");
 			} else {
 				this.fs.copy(
@@ -554,23 +572,23 @@ module.exports = class extends Generator {
 
 		}
 
-        // Iterate over services key deployed under docker images
+		// Iterate over services key deployed under docker images
 		// Retrieve envs, port and images names if availables for each services
-		for (let index = 0; index < this.opts.services.length; index++){
+		for (let index = 0; index < this.opts.services.length; index++) {
 			const servKey = this.opts.services[index];
 
-			if(services[servKey].hasOwnProperty('envs')){
+			if (services[servKey].hasOwnProperty('envs')) {
 				serviceEnvs.push(services[servKey].envs);
 			}
 
-			if(services[servKey].hasOwnProperty('imageName')){
+			if (services[servKey].hasOwnProperty('imageName')) {
 				serviceImageNames.push(services[servKey].imageName);
 			}
 
-			if(services[servKey].hasOwnProperty('imageName')){
+			if (services[servKey].hasOwnProperty('imageName')) {
 				serviceImageNames.push(services[servKey].imageName);
 			}
-			if(services[servKey].hasOwnProperty('port')){
+			if (services[servKey].hasOwnProperty('port')) {
 
 				servicePorts.push(services[servKey].port);
 			}
@@ -603,7 +621,7 @@ module.exports = class extends Generator {
 			applicationId: `${this.bluemix.applicationId}`
 		};
 
-		if (this.fs.exists(this.destinationPath(FILENAME_CLI_CONFIG))){
+		if (this.fs.exists(this.destinationPath(FILENAME_CLI_CONFIG))) {
 			this.log(FILENAME_CLI_CONFIG, "already exists, skipping.");
 		} else {
 			this._writeHandlebarsFile('cli-config-common.yml', FILENAME_CLI_CONFIG, {
@@ -612,7 +630,7 @@ module.exports = class extends Generator {
 			);
 		}
 
-		if (this.fs.exists(this.destinationPath(FILENAME_DOCKERFILE))){
+		if (this.fs.exists(this.destinationPath(FILENAME_DOCKERFILE))) {
 			this.log(FILENAME_DOCKERFILE, "already exists, skipping.");
 		} else {
 			this._writeHandlebarsFile('python/Dockerfile', FILENAME_DOCKERFILE, {
@@ -624,7 +642,7 @@ module.exports = class extends Generator {
 			});
 		}
 
-		if (this.fs.exists(this.destinationPath(FILENAME_DOCKERFILE_TOOLS))){
+		if (this.fs.exists(this.destinationPath(FILENAME_DOCKERFILE_TOOLS))) {
 			this.log(FILENAME_DOCKERFILE_TOOLS, "already exists, skipping.");
 		} else {
 			this._writeHandlebarsFile('python/Dockerfile-tools', FILENAME_DOCKERFILE_TOOLS, {
@@ -634,7 +652,7 @@ module.exports = class extends Generator {
 			});
 		}
 
-		if (this.fs.exists(this.destinationPath(FILENAME_DEV))){
+		if (this.fs.exists(this.destinationPath(FILENAME_DEV))) {
 			this.log(FILENAME_DEV, "already exists, skipping.");
 		} else {
 			this._writeHandlebarsFile('python/run-dev', FILENAME_DEV, {
@@ -646,8 +664,8 @@ module.exports = class extends Generator {
 			});
 		}
 
-		if(this.opts.services.length > 0){
-			const dockerComposeConfig =  {
+		if (this.opts.services.length > 0) {
+			const dockerComposeConfig = {
 				containerName: `${applicationName.toLowerCase()}-django-run`,
 				image: `${applicationName.toLowerCase()}-django-run`,
 				ports: [port, debugPort].concat(servicePorts),
@@ -700,7 +718,7 @@ module.exports = class extends Generator {
 			applicationId: `${this.bluemix.applicationId}`
 		};
 
-		this._writeHandlebarsFile('cli-config-common.yml', FILENAME_CLI_CONFIG, {cliConfig});
+		this._writeHandlebarsFile('cli-config-common.yml', FILENAME_CLI_CONFIG, { cliConfig });
 
 		this._writeHandlebarsFile('go/Dockerfile', FILENAME_DOCKERFILE, { port, applicationName });
 
@@ -708,7 +726,7 @@ module.exports = class extends Generator {
 
 		this._copyTemplateIfNotExists(FILENAME_DOCKER_IGNORE, 'go/dockerignore', {});
 
-		if (this.fs.exists(this.destinationPath(FILENAME_DOCKER_IGNORE))){
+		if (this.fs.exists(this.destinationPath(FILENAME_DOCKER_IGNORE))) {
 			this.log(FILENAME_DOCKER_IGNORE, "already exists, skipping.");
 		} else {
 			this.fs.copyTpl(
@@ -719,7 +737,7 @@ module.exports = class extends Generator {
 	}
 
 	_copyTemplateIfNotExists(targetFileName, sourceTemplatePath, ctx) {
-		if (this.fs.exists(this.destinationPath(targetFileName))){
+		if (this.fs.exists(this.destinationPath(targetFileName))) {
 			this.log(targetFileName, "already exists, skipping.");
 		} else {
 			this.fs.copyTpl(

--- a/generators/dockertools/templates/spring/cli-config.yml.template
+++ b/generators/dockertools/templates/spring/cli-config.yml.template
@@ -5,13 +5,13 @@ ibm-cloud-app-id : "{{applicationId}}"
 {{/exists}}
 
 # The container name used for the run container
-container-name-run : "{{#toLowerCase appName}}{{/toLowerCase}}"
+container-name-run : "{{appNameRefreshed}}"
 
 # The container name used for the tools container
-container-name-tools : "bx-dev-{{#toLowerCase appName}}{{/toLowerCase}}-tools"
+container-name-tools : "bx-dev-{{appNameRefreshed}}-tools"
 
 # The name of image to create from dockerfile-run
-image-name-run : "{{#toLowerCase appName}}{{/toLowerCase}}"
+image-name-run : "{{appNameRefreshed}}"
 {{#has buildType 'maven'}}
 # The name of image to create from dockerfile-tools
 image-name-tools : "bx-dev-java-maven-tools"
@@ -56,7 +56,7 @@ container-port-map : "8080:8080,8443:8443"
 container-port-map-debug : "8000:8000"
 
 # The command to execute debug of the code in the tools container
-debug-cmd : "java -Dspring.profiles.active=local -Xdebug -Xrunjdwp:server=y,transport=dt_socket,address=8000,suspend=y -jar {{#has buildType 'maven'}}./target/{{/has}}{{#has buildType 'gradle'}}./build/libs/{{/has}}{{#firstAvailable artifactId appName}}{{/firstAvailable}}-{{version}}.jar"
+debug-cmd : "java -Dspring.profiles.active=local -Xdebug -Xrunjdwp:server=y,transport=dt_socket,address=8000,suspend=y -jar {{#has buildType 'maven'}}./target/{{/has}}{{#has buildType 'gradle'}}./build/libs/{{/has}}{{#firstAvailable artifactId appNameRefreshed}}{{/firstAvailable}}-{{version}}.jar"
 
 # The name for the dockerfile for the run container
 dockerfile-run : "Dockerfile"
@@ -65,4 +65,4 @@ dockerfile-run : "Dockerfile"
 dockerfile-tools : "Dockerfile-tools"
 
 # The relative path to the helm chart used for Kubernetes deployment
-chart-path : "chart/{{#toLowerCase appName}}{{/toLowerCase}}"
+chart-path : "chart/{{appNameRefreshed}}"

--- a/generators/lib/utils.js
+++ b/generators/lib/utils.js
@@ -22,7 +22,7 @@ const REGEX_ALPHA_NUM_DASH = /[^a-zA-Z0-9-]/g;
 
 const sanitizeAlphaNumLowerCase = (name) => {
 	return sanitizeAlphaNum(name).toLowerCase();
-}
+};
 
 const sanitizeAlphaNum = (name) => {
 	let cleanName = '';
@@ -30,7 +30,7 @@ const sanitizeAlphaNum = (name) => {
 		cleanName = name.replace(REGEX_LEADING_ALPHA, '').replace(REGEX_ALPHA_NUM, '');
 	}
 	return (cleanName || 'APP');
-}
+};
 
 const createUniqueName = (name) => {
 	const hexString = new Buffer(name, 'base64').toString('hex');
@@ -39,7 +39,7 @@ const createUniqueName = (name) => {
 
 	return new Buffer(name, 'base64').toString('hex').substring(0,chars);
 
-}
+};
 
 const sanitizeAlphaNumDash = (name) => {
 	name = name || 'appname';

--- a/package-lock.json
+++ b/package-lock.json
@@ -5603,6 +5603,11 @@
       "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
       "dev": true
     },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+    },
     "scoped-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/scoped-regex/-/scoped-regex-1.0.0.tgz",
@@ -6583,6 +6588,14 @@
       "dev": true,
       "requires": {
         "mkdirp": "^0.5.1"
+      }
+    },
+    "xml-js": {
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/xml-js/-/xml-js-1.6.11.tgz",
+      "integrity": "sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==",
+      "requires": {
+        "sax": "^1.2.4"
       }
     },
     "xtend": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "handlebars": "^4.1.0",
     "js-yaml": "^3.13.0",
     "lodash": "^4.17.11",
-    "yeoman-generator": "^3.2.0"
+    "yeoman-generator": "^3.2.0",
+    "xml-js": "^1.6.11"
   },
   "devDependencies": {
     "coveralls": "^3.0.2",


### PR DESCRIPTION
This PR includes updates to files for Java pattern-types. We will be removing the following files from the static starter kits:
cli-config.yml
Dockerfile*
manifest.yml
Jenkinsfile <-- no longer need
/manifests/kube.deploy.yml <-- no longer needed

The first 3 files in the list will be generated dynamically when an app is created and when necessary will include the new app name in the artifacts. An exception in Spring, which has assets that are named after the `artifactId` from `pom.xml`. Included in this PR is a new Utils function that extracts the `artifactId` from `pom.xml` and assigns it where it's needed-- in Dockerfile and manifest.yml.

This PR also includes some defaults for Java that do not make it in generatorOptions in the case of static starter kits, like buildType and version.