### PR TITLE
Update Swift Dockerfiles to xenial

### DIFF
--- a/generators/dockertools/templates/swift/Dockerfile
+++ b/generators/dockertools/templates/swift/Dockerfile
@@ -1,4 +1,4 @@
-FROM ibmcom/swift-ubuntu-runtime:5.0.1
+FROM ibmcom/swift-ubuntu-xenial-runtime-amd64:5.0.1
 LABEL maintainer="IBM Swift Engineering at IBM Cloud"
 LABEL Description="Template Dockerfile that extends the ibmcom/swift-ubuntu-runtime image."
 

--- a/generators/dockertools/templates/swift/Dockerfile-tools
+++ b/generators/dockertools/templates/swift/Dockerfile-tools
@@ -1,4 +1,4 @@
-FROM ibmcom/swift-ubuntu:5.0.1
+FROM ibmcom/swift-ubuntu-xenial-amd64:5.0.1
 LABEL maintainer="IBM Swift Engineering at IBM Cloud"
 LABEL Description="Template Dockerfile that extends the ibmcom/swift-ubuntu image."
 


### PR DESCRIPTION
The swift `Dockerfile`s are currently based on Ubuntu 14.04 images.  This is out of service and ships back-level packages that cause problems for some of our dependencies and tutorials.  Future releases of Swift will also drop support for 14.04 at some point.
