### PR TITLE
Rebase Dockerfiles on official swift:5.0.2 and swift:5.0.2-slim

### DIFF
--- a/generators/dockertools/templates/swift/Dockerfile
+++ b/generators/dockertools/templates/swift/Dockerfile
@@ -1,6 +1,6 @@
-FROM ibmcom/swift-ubuntu-runtime:5.0.1
+FROM swift:5.0.2-slim
 LABEL maintainer="IBM Swift Engineering at IBM Cloud"
-LABEL Description="Template Dockerfile that extends the ibmcom/swift-ubuntu-runtime image."
+LABEL Description="Template Dockerfile that extends the swift:slim image."
 
 # We can replace this port with what the user wants
 EXPOSE 8080

--- a/generators/dockertools/templates/swift/Dockerfile-tools
+++ b/generators/dockertools/templates/swift/Dockerfile-tools
@@ -1,6 +1,6 @@
-FROM ibmcom/swift-ubuntu:5.0.1
+FROM swift:5.0.2
 LABEL maintainer="IBM Swift Engineering at IBM Cloud"
-LABEL Description="Template Dockerfile that extends the ibmcom/swift-ubuntu image."
+LABEL Description="Template Dockerfile that extends the swift image."
 
 # We can replace this port with what the user wants
 EXPOSE 8080 1024 1025
@@ -18,6 +18,9 @@ RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y \
 {{else}}
 # RUN apt-get update && apt-get dist-upgrade -y
 {{/ifCond}}
+
+# Include base Kitura dependencies
+RUN apt-get update && apt-get install -y sudo libssl-dev libcurl4-openssl-dev
 
 # Add utils files
 ADD https://raw.githubusercontent.com/IBM-Swift/swift-ubuntu-docker/master/utils/tools-utils.sh /swift-utils/tools-utils.sh


### PR DESCRIPTION
Replaces #523 

The Dockerfiles generated for swift projects are currently based on Ubuntu 14.04 images.  This is out of service and ships back-level packages that cause problems for some of our dependencies and tutorials.  Future releases of Swift will also drop support for 14.04 at some point.

The official Swift Dockerfiles now provide a 'slim' image, so we can use these instead.

Note, because the base `swift` images do not include Kitura's dependencies (`libssl-dev`, `libcurl4-openssl-dev`) or `sudo` (assumed by the `Dockerfile-tools`), I have added an install for those packages.  It wasn't clear to me how this could be achieved through `serviceItems`, but I'd be happy to be guided on how to use this instead if it's the preferred approach.

Note also, that the runtime requirements for Kitura (`libcurl` and `libssl` libraries) are already satisfied by the `swift:slim` image, so no additional packages need to be installed in the `Dockerfile`.