### PR TITLE
fix(swift): update manifest with swift buildpack environment variable

### DIFF
--- a/generators/deployment/index.js
+++ b/generators/deployment/index.js
@@ -204,6 +204,7 @@ module.exports = class extends Generator {
 			// cannot read file or find a command, return to default behavior
 		}
 		this.manifestConfig.command = manifestCommand;
+		this.manifestConfig.env.SWIFT_BUILD_DIR_CACHE = false;
 		this.manifestConfig.memory = this.manifestConfig.memory || '128M';
 		this.pipelineConfig.swift = true;
 		this.cfIgnoreContent = ['.build/*', '.build-ubuntu/*', 'Packages/*'];

--- a/test/test-cloudfoundry.js
+++ b/test/test-cloudfoundry.js
@@ -83,6 +83,11 @@ describe('cloud-enablement:cloudfoundry', function () {
 			assert.fileContent('manifest.yml', 'memory: 1024M');
 		});
 
+		it('manifest.yml has SWIFT_BUILD_DIR_CACHE set to false', function () {
+			assert.file('manifest.yml');
+			assert.fileContent('manifest.yml', 'SWIFT_BUILD_DIR_CACHE : false');
+		});
+
 		it('toolchain.yml repo type is clone', function () {
 			assert.file('.bluemix/toolchain.yml');
 			assert.fileContent('.bluemix/toolchain.yml', 'type: clone');


### PR DESCRIPTION
this workaround fixes the cf failures with the buildpack hitting the disk quota limit